### PR TITLE
Disable table of contents for DOCX output

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -84,7 +84,7 @@ format:
     number-depth: 3
     colorlinks: true
   docx:
-    toc: true
+    toc: false
     number-sections: true
     highlight-style: github
   epub:


### PR DESCRIPTION
causes issues when comparing documents, and isn't really necessary since users can use the outline view in the navigation pane