### PR TITLE
fix intro to cp instructions

### DIFF
--- a/ai-tools/copilot-instructions-explanation.qmd
+++ b/ai-tools/copilot-instructions-explanation.qmd
@@ -21,9 +21,7 @@ This reduces the review burden and helps maintain consistency
 across all contributions to the lab manual,
 whether made by humans or AI assistants.
 
-Unfortunately, we can't render the `copilot-instructions.md` file 
-as part of this lab manual, 
-because it includes dummy
+Here is the complete `copilot-instructions.md` file, for easy inspection:
 
 ::: {.callout-note collapse="true"}
 ## View copilot-instructions.md


### PR DESCRIPTION
This pull request updates the `ai-tools/copilot-instructions-explanation.qmd` file to include the full contents of `copilot-instructions.md` directly in the documentation, making it easier for users to review the instructions without switching files.

Documentation improvement:

* The full `copilot-instructions.md` file is now rendered within the `ai-tools/copilot-instructions-explanation.qmd` file for easier inspection, replacing the previous explanation about why it could not be included.