### PR TITLE
Convert CRITICAL version warning into a callout

### DIFF
--- a/coding-practices/version-control-and-collaboration.qmd
+++ b/coding-practices/version-control-and-collaboration.qmd
@@ -9,7 +9,7 @@ Follow semantic versioning (MAJOR.MINOR.PATCH):
 - Breaking changes: increment MAJOR (e.g., `0.2.0` → `1.0.0`)
 
 ::: {.callout-important}
-## Keep the development version ahead
+#### Keep the development version ahead
 
 Always keep the development version ahead of the main branch version.
 When working on a development branch,

--- a/coding-practices/version-control-and-collaboration.qmd
+++ b/coding-practices/version-control-and-collaboration.qmd
@@ -8,9 +8,13 @@ Follow semantic versioning (MAJOR.MINOR.PATCH):
 - New features: increment MINOR (e.g., `0.1.1` → `0.2.0`)
 - Breaking changes: increment MAJOR (e.g., `0.2.0` → `1.0.0`)
 
-**CRITICAL**: Always keep the development version ahead of the main branch version.
+::: {.callout-important}
+## Keep the development version ahead
+
+Always keep the development version ahead of the main branch version.
 When working on a development branch,
 ensure the version in `DESCRIPTION` is higher than the version on `main`.
+:::
 
 ```r
 # Increment version


### PR DESCRIPTION
## Summary

Converts the bold **CRITICAL** version-numbering warning in the version control section of the coding practices chapter into a proper Quarto callout, matching the callout convention used elsewhere in the manual.

The text now renders as a `::: {.callout-important}` block titled "Keep the development version ahead" instead of an inline `**CRITICAL**:` paragraph.

## Location

`coding-practices/version-control-and-collaboration.qmd` — the [R version control section](https://ucd-serg.github.io/lab-manual/coding-practices.html#sec-r-version-control).

https://claude.ai/code/session_01J9Ty8L53Fk4dunAP6e9jMW

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9Ty8L53Fk4dunAP6e9jMW)_