### PR TITLE
Document load_all() before lint_package() for package code

### DIFF
--- a/coding-practices/automated-code-styling.qmd
+++ b/coding-practices/automated-code-styling.qmd
@@ -25,8 +25,12 @@ styler::style_pkg()
 For checking code style without modifying files:
 
 ```r
-# Install lintr
-install.packages("lintr")
+# Install lintr (and pkgload, used below)
+install.packages(c("lintr", "pkgload"))
+
+# For package code, load the package first so object_usage_linter()
+# checks your current source (see the style guide for details)
+pkgload::load_all()
 
 # Lint the entire package
 lintr::lint_package()

--- a/coding-practices/quality-assurance-checklist.qmd
+++ b/coding-practices/quality-assurance-checklist.qmd
@@ -5,7 +5,8 @@ Before requesting human review on a pull request or finalizing analysis, verify:
 - [ ] `devtools::document()` has been run
 - [ ] `devtools::test()` passes with no failures
 - [ ] `devtools::check()` passes with no errors, warnings, or notes
-- [ ] `lintr::lint_package()` shows no issues (or only acceptable ones)
+- [ ] `lintr::lint_package()` shows no issues (or only acceptable ones);
+      run `pkgload::load_all()` first so `object_usage_linter()` checks current source
 - [ ] `spelling::spell_check_package()` passes
 - [ ] Version number has been incremented
 - [ ] `NEWS.md` has been updated with changes

--- a/coding-style/_lintr-summary.qmd
+++ b/coding-style/_lintr-summary.qmd
@@ -29,8 +29,8 @@ The styler can be used to automatically fix the problems that the lintr catches.
 For checking code style without modifying files:
 
 ```r
-# Install lintr
-install.packages("lintr")
+# Install lintr (and pkgload, used below)
+install.packages(c("lintr", "pkgload"))
 
 # For package code, load the package first (see note below)
 pkgload::load_all()
@@ -52,8 +52,8 @@ The linter checks for:
 For package code, run `pkgload::load_all()` (or `devtools::load_all()`) **before**
 `lintr::lint_package()`. Our configuration includes `object_usage_linter()`, which
 resolves symbols using the loaded package; without loading first, it checks against a
-stale installed copy (or none), producing spurious "no visible binding for global
-variable" warnings. Loading also runs any `.onLoad()` side effects: for example, our
+stale installed copy (or none), producing spurious
+`no visible binding for global variable` warnings. Loading also runs any `.onLoad()` side effects: for example, our
 [`lms`](https://github.com/UCD-SERG/lab-manual/tree/main/lms) linter package registers
 its `rex` shortcuts in `.onLoad()`, and the linter only sees them once the package is
 loaded.

--- a/coding-style/_lintr-summary.qmd
+++ b/coding-style/_lintr-summary.qmd
@@ -32,6 +32,9 @@ For checking code style without modifying files:
 # Install lintr
 install.packages("lintr")
 
+# For package code, load the package first (see note below)
+pkgload::load_all()
+
 # Lint the entire package
 lintr::lint_package()
 
@@ -45,6 +48,15 @@ The linter checks for:
 - Improper whitespace
 - Line length issues
 - Style guide violations
+
+For package code, run `pkgload::load_all()` (or `devtools::load_all()`) **before**
+`lintr::lint_package()`. Our configuration includes `object_usage_linter()`, which
+resolves symbols using the loaded package; without loading first, it checks against a
+stale installed copy (or none), producing spurious "no visible binding for global
+variable" warnings. Loading also runs any `.onLoad()` side effects: for example, our
+[`lms`](https://github.com/UCD-SERG/lab-manual/tree/main/lms) linter package registers
+its `rex` shortcuts in `.onLoad()`, and the linter only sees them once the package is
+loaded.
 
 Our lab uses `.lintr.R` files for configuration (the `.lintr` format is also supported by lintr,
 but we prefer `.lintr.R` for better R syntax support).


### PR DESCRIPTION
## What

Documents that package code should be loaded with `pkgload::load_all()` (or `devtools::load_all()`) **before** running `lintr::lint_package()`. The manual mentioned `lint_package()` in three places but never connected it to `load_all()`.

## Why

Our lintr config includes `object_usage_linter()` (a `linters_with_defaults` default). It resolves symbols using the loaded package, so without loading first it checks a stale installed copy (or none) and emits spurious **"no visible binding for global variable"** warnings. Loading also runs `.onLoad()` side effects — directly relevant to the new [`lms`](https://github.com/UCD-SERG/lab-manual/tree/main/lms) linter package, whose `.onLoad()` registers the `rex` DSL shortcuts so `object_usage_linter` recognizes them.

## Changes

- `coding-style/_lintr-summary.qmd`: add `pkgload::load_all()` to the example and a short note explaining the why (incl. the `lms`/`rex` `.onLoad` case).
- `coding-practices/quality-assurance-checklist.qmd`: note `load_all()` on the `lint_package()` checklist item.
- `coding-practices/automated-code-styling.qmd`: add the `load_all()` step to its `lint_package()` example (the third location).

Docs-only; no code or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)