### PR TITLE
check-dois: validate present DOIs on exempt entries

### DIFF
--- a/.github/scripts/check-bibliography-dois.R
+++ b/.github/scripts/check-bibliography-dois.R
@@ -279,9 +279,11 @@ check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
       next
     }
 
-    # Skip entries exempt from the DOI requirement (DOI-less online books)
-    if (entry$BIBTEXKEY %in% DOI_EXEMPT) {
-      cat(sprintf("  Skipping %s '%s' (DOI-exempt)\n", entry_type, entry$BIBTEXKEY))
+    # DOI-exempt entries are allowed to have no DOI. Only skip when the DOI
+    # is actually absent; if one is present it is still validated below.
+    doi_present <- !(is.na(entry$DOI) || entry$DOI == "")
+    if (entry$BIBTEXKEY %in% DOI_EXEMPT && !doi_present) {
+      cat(sprintf("  Skipping %s '%s' (DOI-exempt, no DOI)\n", entry_type, entry$BIBTEXKEY))
       next
     }
 

--- a/.github/scripts/check-bibliography-dois.R
+++ b/.github/scripts/check-bibliography-dois.R
@@ -281,7 +281,7 @@ check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
 
     # DOI-exempt entries are allowed to have no DOI. Only skip when the DOI
     # is actually absent; if one is present it is still validated below.
-    doi_present <- !(is.na(entry$DOI) || entry$DOI == "")
+    doi_present <- !is.na(entry$DOI) && nzchar(trimws(entry$DOI))
     if (entry$BIBTEXKEY %in% DOI_EXEMPT && !doi_present) {
       cat(sprintf("  Skipping %s '%s' (DOI-exempt, no DOI)\n", entry_type, entry$BIBTEXKEY))
       next


### PR DESCRIPTION
Follow-up to a Copilot finding on #309 that was raised right at merge time, so it landed in `main` unaddressed.

`DOI_EXEMPT` entries (DOI-less online books) were skipped **unconditionally** in the check loop. That meant if a DOI were later added to an exempt entry, it would *not* be validated — contradicting the script/README statement that "DOIs that are present are still validated."

**Fix:** only skip an exempt entry when its DOI field is actually absent; a present DOI (even on an exempt key) now falls through to URL + metadata validation.

No behavior change for the current bibliography (all four exempt entries have no DOI, so they're still skipped). `check-dois` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)