### PR TITLE
preview: cache TinyTeX to fix flaky luatexbase TeX failures

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,6 +34,18 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
+      # Restore the TinyTeX tree (with LaTeX packages installed by prior
+      # renders) so the PDF render reuses them instead of refetching via
+      # tlmgr on every run. Live tlmgr fetches intermittently fail to resolve
+      # packages (e.g. "luatexbase.sty not found"), the recurring cause of red
+      # preview builds. After a successful run the populated tree is cached, so
+      # subsequent runs don't hit the network for TeX packages.
+      - name: Cache TinyTeX
+        uses: actions/cache@v4
+        with:
+          path: ~/.TinyTeX
+          key: tinytex-${{ runner.os }}-v1
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:


### PR DESCRIPTION
## Problem

The Quarto **preview** build (`preview.yml`) renders the book including PDF (`lualatex`). On every run, `lualatex` lazily fetches LaTeX packages via TinyTeX's `tlmgr`. When TeX Live's mirror is degraded, `tlmgr` fails to resolve packages — `LaTeX Error: File 'luatexbase.sty' not found` — and the whole `build-deploy` job reds.

This was observed flickering across **multiple** branches in the same window (e.g. #301 and #310 failed while #311 passed), confirming it's environmental, not content.

## Fix

Cache `~/.TinyTeX` (the TinyTeX tree) keyed on the OS. Once a run populates the LaTeX packages, subsequent runs restore them from cache and the render reuses them — no per-run network fetch for TeX packages, so transient `tlmgr` outages can't red the build.

Minimal change: one `actions/cache@v4` step before the Quarto setup; no change to render output (PDF still produced).

## Notes
- Needs one successful "seed" run to populate the cache; while TeX Live is currently degraded the seed run may still be red until the outage clears, after which it's reliable.
- `publish.yml` (production deploy) has the same lazy-`tlmgr` pattern and would benefit from the identical cache step — left out here to keep this PR focused; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)