### PR TITLE
Drop dangling intro sentence in ways-to-interact-with-agents

### DIFF
--- a/ai-tools/ways-to-interact-with-agents.qmd
+++ b/ai-tools/ways-to-interact-with-agents.qmd
@@ -1,5 +1,3 @@
-You can ask for similar coding work through different interfaces,
-but the trade-offs are different.
 The main differences are where the agent runs,
 how much repository context it can access,
 and how directly it can apply changes.


### PR DESCRIPTION
Follow-up to a post-merge `@claude` review finding on #273 (which merged before the finding could be addressed).

The first sentence of the `ways-to-interact-with-agents.qmd` include — *"You can ask for similar coding work through different interfaces, but the trade-offs are different."* — had a dangling "similar" (no referent) and duplicated the intro already in `how-to-work-with-agents.qmd`. The section now opens with *"The main differences are…"*.

(The review's other flag — a `---` "triple-dash" — was rebutted: `---` is the repo's required ASCII em-dash convention; `—` fails `check-non-standard-chars`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)