### PR TITLE
ci: migrate Claude workflows to shared d-morrison/gha reusable workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
       pr_number:
         description: 'Pull request number to review'
         required: true
-        type: number
+        type: string
 
 jobs:
   review:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,44 +1,29 @@
+# Calls the shared reusable Claude Code Review workflow in d-morrison/gha.
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret (passed via
+# `secrets: inherit`). Keep this file named claude-code-review.yml so claude.yml
+# can re-dispatch a review after an @claude run pushes commits.
 name: Claude Code Review
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: number
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
+  review:
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
+    secrets: inherit
+    with:
+      # Wires the workflow_dispatch input through so claude.yml can re-dispatch a
+      # review on Claude's commits; empty (and ignored) for pull_request runs.
+      pr-number: ${{ inputs.pr_number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,6 @@
+# Calls the shared reusable Claude Code workflow in d-morrison/gha.
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret; `secrets: inherit`
+# passes it (and any optional WORKFLOW_TOKEN) through to the reusable workflow.
 name: Claude Code
 
 on:
@@ -12,39 +15,24 @@ on:
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-
+      actions: write
+    uses: d-morrison/gha/.github/workflows/claude.yml@v1
+    secrets: inherit
+    with:
+      # The lab manual is a Quarto book, so Claude needs Quarto to render
+      # chapters. Dependencies are installed from DESCRIPTION as RSPM binaries
+      # (the reusable workflow's default) rather than via an renv restore, which
+      # would also need the preview workflow's system libraries.
+      install-quarto: true
+      prompt-addendum: |
+        This is the UCD-SERG lab manual, a Quarto book. Follow the manual's own
+        coding-style and coding-practices conventions. Keep prose ASCII — the
+        check-non-standard-chars workflow flags non-standard characters such as
+        curly quotes and en/em dashes. Before committing a changed chapter, run
+        spelling::spell_check_files() on it and, where feasible, `quarto render`
+        the affected .qmd.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,12 +15,21 @@ on:
 
 jobs:
   claude:
+    # Cheap caller-side gate: only invoke the reusable workflow when an @claude
+    # mention is actually present, so unrelated comments / reviews / issue
+    # events don't spawn a (skipped) reusable-workflow run. The reusable
+    # workflow still enforces the trusted-author gate (OWNER/MEMBER/COLLABORATOR).
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
-      actions: write
+      actions: write       # dispatch the review workflow via `gh workflow run`
     uses: d-morrison/gha/.github/workflows/claude.yml@v1
     secrets: inherit
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
     with:
       # The lab manual is a Quarto book, so Claude needs Quarto to render
       # chapters. Dependencies are installed from DESCRIPTION as RSPM binaries
-      # (the reusable workflow's default) rather than via an renv restore, which
+      # (the reusable workflow's default) rather than via a renv restore, which
       # would also need the preview workflow's system libraries.
       install-quarto: true
       prompt-addendum: |
         This is the UCD-SERG lab manual, a Quarto book. Follow the manual's own
-        coding-style and coding-practices conventions. Keep prose ASCII — the
+        coding-style and coding-practices conventions. Keep prose ASCII: the
         check-non-standard-chars workflow flags non-standard characters such as
         curly quotes and en/em dashes. Before committing a changed chapter, run
         spelling::spell_check_files() on it and, where feasible, `quarto render`


### PR DESCRIPTION
## What

Replaces the two self-contained Claude Code workflows with thin caller stubs that invoke the centralized reusable workflows in [`d-morrison/gha`](https://github.com/d-morrison/gha) (pinned `@v1`), matching the patterns in `gha/examples/`.

- **`claude.yml`** → calls `d-morrison/gha/.github/workflows/claude.yml@v1`
- **`claude-code-review.yml`** → calls `d-morrison/gha/.github/workflows/claude-code-review.yml@v1`

## Why

Centralizing keeps the Claude automation in lockstep with the other `d-morrison` / `UCD-SERG` repos and pulls in capabilities the current inline workflows lack:

- **Trusted-author gate** — only `OWNER` / `MEMBER` / `COLLABORATOR` can trigger a run (the current `claude.yml` only checks for the `@claude` string).
- **Agent-mode PR machinery** — branch setup, commit pushing, draft-PR open/finalize, and prose-reply posting, so an `@claude` mention on an *issue* yields a PR.
- **Per-issue/PR concurrency** so rapid mentions don't race.
- **Reviewer workflow** that posts inline findings and re-dispatches itself after `@claude` pushes commits (`workflow_dispatch` `pr_number` wired through).

## Lab-manual-specific configuration

- `install-quarto: true` so Claude can render `.qmd` chapters.
- Dependencies come from `DESCRIPTION` as RSPM binaries (the reusable workflow's default) rather than an `renv` restore — lighter and avoids needing the preview workflow's system libraries (jags, libcurl, …).
- A `prompt-addendum` pointing Claude at the manual's own coding conventions, the ASCII/`check-non-standard-chars` rule, and per-chapter spell-check/render before committing.

## Notes

- Requires the existing `CLAUDE_CODE_OAUTH_TOKEN` repository secret (passed via `secrets: inherit`); no new secrets required.
- If full-book render fidelity is later needed, switch the caller to `use-renv: true` (and the reusable workflow may need the preview build's system deps added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXAbFu5BGnJ71xKPnDjz4

---
_Generated by [Claude Code](https://claude.ai/code/session_019uXAbFu5BGnJ71xKPnDjz4)_