### PR TITLE
docs(ai-tools): add Agent Skills section linking to agentskills.io and d-morrison/ai-config

### DIFF
--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -80,6 +80,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/copilot-setup-steps-config.qmd >}}
 
+### Agent Skills {#sec-ai-agent-skills}
+
+{{< include ai-tools/agent-skills.qmd >}}
+
 ### When to use a coding agent {#sec-ai-when-to-use}
 
 {{< include ai-tools/when-to-use-coding-agent.qmd >}}

--- a/ai-tools/agent-skills.qmd
+++ b/ai-tools/agent-skills.qmd
@@ -8,7 +8,8 @@ tool-agnostic format that any compatible agent can load.
 #### What is a Skill?
 
 At its core, a skill is a folder containing a `SKILL.md` file.
-This file includes required metadata (`name` and `description`)
+This file includes the `name` and `description` metadata
+[required by the specification](https://agentskills.io/specification),
 along with instructions that tell an agent how to perform a specific task.
 Skills can also bundle supporting resources:
 

--- a/ai-tools/agent-skills.qmd
+++ b/ai-tools/agent-skills.qmd
@@ -1,0 +1,61 @@
+
+[Agent Skills](https://agentskills.io/home) are a lightweight,
+open standard for extending AI agent capabilities
+with specialized knowledge and workflows.
+Originally developed by Anthropic and released as an open standard,
+Agent Skills are now supported by a wide range of coding agent tools,
+including GitHub Copilot, Claude Code, Cursor, Gemini CLI, and many others
+(as of June 2026).
+
+#### What is a Skill?
+
+At its core, a skill is a folder containing a `SKILL.md` file.
+This file includes required metadata (`name` and `description`)
+along with instructions that tell an agent how to perform a specific task.
+Skills can also bundle supporting resources:
+
+- Scripts
+- Reference documentation
+- Templates and assets
+
+```
+my-skill/
+├── SKILL.md          # Required: metadata + instructions
+├── scripts/          # Optional: executable code
+├── references/       # Optional: documentation
+└── assets/           # Optional: templates, resources
+```
+
+#### How Agents Load Skills
+
+Agents load skills through a process called *progressive disclosure*,
+in three stages:
+
+1. **Discovery**: At startup, the agent loads only the name and description
+   of each available skill — just enough to know when it might be relevant.
+2. **Activation**: When a task matches a skill's description,
+   the agent reads the full `SKILL.md` instructions into context.
+3. **Execution**: The agent follows the instructions,
+   optionally executing bundled scripts or loading referenced files as needed.
+
+This means full instructions load only when needed,
+so agents can maintain many skills with a small context footprint.
+
+#### Why Use Skills?
+
+Skills package procedural knowledge and team-specific context
+into portable, version-controlled folders.
+This gives agents:
+
+- **Domain expertise**: Capture specialized knowledge as reusable instructions
+- **Repeatable workflows**: Turn multi-step tasks into consistent, auditable procedures
+- **Cross-tool reuse**: Build a skill once and use it across any skills-compatible agent
+
+#### Further Reading
+
+For the complete specification and more details,
+see [agentskills.io](https://agentskills.io/home).
+
+The [d-morrison/claude-config](https://github.com/d-morrison/claude-config) repository
+contains an example of Claude-specific configuration files,
+including Claude skills and related settings.

--- a/ai-tools/agent-skills.qmd
+++ b/ai-tools/agent-skills.qmd
@@ -56,6 +56,6 @@ This gives agents:
 For the complete specification and more details,
 see [agentskills.io](https://agentskills.io/home).
 
-The [d-morrison/claude-config](https://github.com/d-morrison/claude-config) repository
-contains an example of Claude-specific configuration files,
-including Claude skills and related settings.
+The [d-morrison/ai-config](https://github.com/d-morrison/ai-config) repository
+contains an example of personal Claude Code configuration,
+including user-level skills and slash commands, synced across machines via git.

--- a/ai-tools/agent-skills.qmd
+++ b/ai-tools/agent-skills.qmd
@@ -2,8 +2,8 @@
 [Agent Skills](https://agentskills.io/home) are a lightweight,
 open standard for extending AI agent capabilities
 with specialized knowledge and workflows.
-Introduced by Anthropic and released as an open standard,
-they are supported by a growing range of coding agents.
+The [specification](https://agentskills.io/specification) defines a portable,
+tool-agnostic format that any compatible agent can load.
 
 #### What is a Skill?
 
@@ -26,8 +26,8 @@ my-skill/
 
 #### How Agents Load Skills
 
-Agents load skills through a process called *progressive disclosure*,
-in three stages:
+The specification describes a *progressive disclosure* model,
+in which an agent typically loads a skill in three stages:
 
 1. **Discovery**: At startup, the agent loads only the name and description
    of each available skill --- just enough to know when it might be relevant.

--- a/ai-tools/agent-skills.qmd
+++ b/ai-tools/agent-skills.qmd
@@ -2,10 +2,8 @@
 [Agent Skills](https://agentskills.io/home) are a lightweight,
 open standard for extending AI agent capabilities
 with specialized knowledge and workflows.
-Originally developed by Anthropic and released as an open standard,
-Agent Skills are now supported by a wide range of coding agent tools,
-including GitHub Copilot, Claude Code, Cursor, Gemini CLI, and many others
-(as of June 2026).
+Introduced by Anthropic and released as an open standard,
+they are supported by a growing range of coding agents.
 
 #### What is a Skill?
 
@@ -32,7 +30,7 @@ Agents load skills through a process called *progressive disclosure*,
 in three stages:
 
 1. **Discovery**: At startup, the agent loads only the name and description
-   of each available skill — just enough to know when it might be relevant.
+   of each available skill --- just enough to know when it might be relevant.
 2. **Activation**: When a task matches a skill's description,
    the agent reads the full `SKILL.md` instructions into context.
 3. **Execution**: The agent follows the instructions,
@@ -58,4 +56,4 @@ see [agentskills.io](https://agentskills.io/home).
 
 The [d-morrison/ai-config](https://github.com/d-morrison/ai-config) repository
 contains an example of personal Claude Code configuration,
-including user-level skills and slash commands, synced across machines via git.
+including user-level skills and slash commands, synced across machines via Git.


### PR DESCRIPTION
## What

Adds an **Agent Skills** subsection to the AI tools chapter (finishing the work started on this branch by the `@claude` run on #287):

- New partial `ai-tools/agent-skills.qmd` summarizing the [Agent Skills](https://agentskills.io/home) open standard (the `SKILL.md` folder structure, the discovery → activation → execution lifecycle, and why skills are useful).
- Wires it into `ai-tools.qmd` as `### Agent Skills {#sec-ai-agent-skills}`.
- Links to [agentskills.io](https://agentskills.io/home) and to [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a concrete example.

## Link correction

The original draft linked to `d-morrison/claude-config`, which the `@claude` run [flagged it couldn't verify](https://github.com/UCD-SERG/lab-manual/issues/287#issuecomment-4736665214) (no GitHub API access in that run). That repository has since been **renamed to `d-morrison/ai-config`** — its README still opens `# claude-config` and describes "Portable Claude Code config — synced across machines via git" (`skills/`, `commands/`). The old URL still redirects, but this PR points the link at the current canonical name and refines the description accordingly.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uXAbFu5BGnJ71xKPnDjz4

---
_Generated by [Claude Code](https://claude.ai/code/session_019uXAbFu5BGnJ71xKPnDjz4)_