### PR TITLE
Add ai-config skills as a submodule

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^renv\.lock$
 ^\.lintr\.R$
 ^lms$
+^\.ai-config$
+^\.claude$

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,37 @@
+# `.claude/`
+
+Project-level Claude Code config for this repo.
+
+## `skills/` → shared skills via the `.ai-config` submodule
+
+`skills` is a **symlink** to `../.ai-config/skills`, the `skills/` directory of
+the [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) repo,
+which is vendored here as a git submodule at `.ai-config` (see `.gitmodules`).
+
+This makes those reusable skills available as **project skills** to:
+
+- local Claude Code CLI sessions opened on this repo, and
+- the `@claude` GitHub Actions bot (`.github/workflows/claude.yml`), which loads
+  skills from `.claude/skills/` in the checked-out repo. The workflow's checkout
+  step uses `submodules: recursive` so the submodule is populated in CI.
+
+### Populating the submodule after cloning
+
+A plain `git clone` leaves the submodule empty and the symlink dangling. Run:
+
+```sh
+git submodule update --init --recursive
+```
+
+(or clone with `git clone --recurse-submodules`).
+
+### Updating to newer skills
+
+The submodule is pinned to a specific `ai-config` commit. To bump it:
+
+```sh
+git -C .ai-config fetch origin
+git -C .ai-config checkout origin/main
+git add .ai-config
+git commit -m "Bump .ai-config submodule"
+```

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.ai-config/skills

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # claude-code-action's restoreConfigFromBase touches .claude, which
+          # contains a skills symlink into the .ai-config submodule. The
+          # submodule must be checked out or the symlink dangles and the action
+          # errors (ENOENT statx '.claude/skills'). fetch-depth: 0 keeps the
+          # pinned submodule commit fetchable as .ai-config advances.
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          # Pull in the .ai-config submodule so the @claude bot can load the
+          # shared skills committed at .claude/skills -> ../.ai-config/skills.
+          submodules: recursive
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # Full history is required alongside submodules: a shallow clone only
+          # fetches the submodule's branch tip, so CI would break once the pinned
+          # .ai-config commit is no longer that tip.
+          fetch-depth: 0
           # Pull in the .ai-config submodule so the @claude bot can load the
           # shared skills committed at .claude/skills -> ../.ai-config/skills.
           submodules: recursive

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ai-config"]
+	path = .ai-config
+	url = https://github.com/d-morrison/ai-config.git


### PR DESCRIPTION
## What

Vendor [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a git submodule and expose its reusable skills inside this repo.

## Changes

- **`.gitmodules` + `.ai-config`** — adds `d-morrison/ai-config` as a submodule at `.ai-config` (hidden root dir), pinned to `c7ed10a`.
- **`.claude/skills` → `../.ai-config/skills`** — committed symlink (mode `120000`) so the 60 shared skills are discovered as **project skills** by:
  - local Claude Code CLI sessions opened on this repo, and
  - the `@claude` GitHub Actions bot, which loads skills from `.claude/skills/` in the checked-out repo.
- **`.github/workflows/claude.yml` + `claude-code-review.yml`** — after merging `main`'s migration to the shared `d-morrison/gha` reusable workflows, both caller stubs set **`checkout-submodules: true`** so the `.ai-config` submodule is checked out and the committed symlink resolves (`ai-config` is public, so no `SUBMODULES_TOKEN` is needed). Without it, `claude-code-action`'s `restoreConfigFromBase` errors with `ENOENT statx '.claude/skills'`.
- **`.Rbuildignore`** — excludes `^\.ai-config$` and `^\.claude$` from the R-package build.
- **`.claude/README.md`** — documents the submodule+symlink mechanism and how to populate/bump it.

## Mechanism note

This mirrors how `ai-config` exposes its skills to its own `@claude` bot, and matches the `link-skills` guidance in the `d-morrison/gha` reusable workflow: because `claude-code-action`'s `restoreConfigFromBase` restores `.claude/` from the **base branch**, the `.claude/skills` symlink only takes effect for the bot **after this PR merges to `main`** — local CLI sessions see it immediately.

Contributors who clone without `--recurse-submodules` should run `git submodule update --init --recursive` to populate `.ai-config` (otherwise the symlink dangles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)