### PR TITLE
docs(ai-tools): document Claude Code cloud environments and /remote-env

### DIFF
--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -80,6 +80,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/copilot-setup-steps-config.qmd >}}
 
+### Claude Code Cloud Environments {#sec-ai-claude-cloud-env}
+
+{{< include ai-tools/claude-code-cloud-environments.qmd >}}
+
 ### When to use a coding agent {#sec-ai-when-to-use}
 
 {{< include ai-tools/when-to-use-coding-agent.qmd >}}

--- a/ai-tools/claude-code-cloud-environments.qmd
+++ b/ai-tools/claude-code-cloud-environments.qmd
@@ -37,10 +37,12 @@ for `--remote` runs:
 `/remote-env` only *selects* the default;
 to add, edit, or archive the environments themselves,
 use the web interface at [claude.ai/code](https://claude.ai/code).
-Because it opens an interactive panel,
+Because `/remote-env` opens an interactive panel,
 run it from an interactive `claude` terminal session.
 
 ::: {.callout-note}
+#### Availability
+
 Claude Code on the web
 (and the cloud environments it relies on)
 is a research-preview feature,

--- a/ai-tools/claude-code-cloud-environments.qmd
+++ b/ai-tools/claude-code-cloud-environments.qmd
@@ -1,0 +1,54 @@
+[Claude Code](https://www.anthropic.com/claude-code)
+is a CLI coding agent
+that can also run tasks on Anthropic-managed cloud infrastructure---
+either from the web at [claude.ai/code](https://claude.ai/code)
+("Claude Code on the web"),
+or from the terminal by adding the `--remote` flag
+to move a session into the cloud.
+
+Each cloud run executes inside a configured **environment**.
+An environment bundles three things:
+
+- **Network access level**:
+  what the cloud session is allowed to reach
+  (a security control,
+  analogous to the firewall configuration described above).
+- **Environment variables**:
+  values the session needs at runtime,
+  such as `NODE_ENV`,
+  database URLs,
+  or API keys.
+- **Setup scripts**:
+  Bash that runs automatically when the session starts,
+  for example to install dependencies.
+
+#### Selecting the default environment with `/remote-env`
+
+The `/remote-env` slash command sets
+**which configured environment is the default**
+for `--remote` runs:
+
+- With a single environment configured,
+  it shows your current configuration.
+- With multiple environments,
+  it opens an interactive picker
+  so you can choose the default.
+
+`/remote-env` only *selects* the default;
+to add, edit, or archive the environments themselves,
+use the web interface at [claude.ai/code](https://claude.ai/code).
+Because it opens an interactive panel,
+run it from an interactive `claude` terminal session.
+
+::: {.callout-note}
+Claude Code on the web
+(and the cloud environments it relies on)
+is a research-preview feature,
+available to Pro, Max, and Team users
+(and Enterprise users with eligible seats).
+Availability and behavior may change.
+:::
+
+For details,
+see the [Claude Code on the web documentation](https://code.claude.com/docs/en/claude-code-on-the-web)
+and the [slash command reference](https://code.claude.com/docs/en/commands).


### PR DESCRIPTION
## What

Adds a **Claude Code Cloud Environments** subsection to the *Working with AI* chapter (`ai-tools.qmd`), grouped with the other agent-environment/config sections.

The new include snippet `ai-tools/claude-code-cloud-environments.qmd` covers:

- Running Claude Code in the cloud — from the web at [claude.ai/code](https://claude.ai/code) or from the terminal via the `--remote` flag.
- The configurable **environment** each cloud run uses: network access level, environment variables, and setup scripts.
- The `/remote-env` slash command for selecting the default environment for `--remote` runs.
- A research-preview availability note, with links to the official docs.

## Why

The chapter previously documented only GitHub Copilot tooling. This fills in the Claude Code cloud-execution workflow that lab members are starting to use.

## Verification

- `quarto render ai-tools.qmd` → `Output created: docs/ai-tools.html`, exit 0.
- Local spell check (`spelling::spell_check_files`) against `inst/WORDLIST`: no real misspellings (only URL/Quarto-syntax false positives, which CI's `spell_check_package` does not scan in chapter `.qmd` files anyway).
- Style matches the chapter's existing snippets: semantic line breaks, `####` nesting, `.callout-note`, verified doc links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)