### PR TITLE
ci: pass Claude secrets explicitly (fix empty OAuth token from cross-owner inherit)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,11 @@
 # Calls the shared reusable Claude Code Review workflow in d-morrison/gha.
 # Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret. It is passed
-# EXPLICITLY (not `secrets: inherit`): the reusable workflow lives in the
-# d-morrison *user* account while this repo is in the *UCD-SERG org*, and
-# GitHub only inherits secrets into a reusable workflow owned by the same
-# org/user. Cross-owner `secrets: inherit` silently passes an empty token,
-# so the reviewer dies with "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN,
-# ... is required". Keep this file named claude-code-review.yml so claude.yml
+# explicitly (not `secrets: inherit`): the reusable workflow lives in the
+# d-morrison user account while this repo is in the UCD-SERG org, and GitHub
+# only inherits secrets into a reusable workflow owned by the same org/user.
+# Cross-owner `secrets: inherit` silently passes an empty token, so the
+# reviewer dies with "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ...
+# is required". Keep this file named claude-code-review.yml so claude.yml
 # can re-dispatch a review after an @claude run pushes commits.
 name: Claude Code Review
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,11 @@
 # Calls the shared reusable Claude Code Review workflow in d-morrison/gha.
-# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret (passed via
-# `secrets: inherit`). Keep this file named claude-code-review.yml so claude.yml
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret. It is passed
+# EXPLICITLY (not `secrets: inherit`): the reusable workflow lives in the
+# d-morrison *user* account while this repo is in the *UCD-SERG org*, and
+# GitHub only inherits secrets into a reusable workflow owned by the same
+# org/user. Cross-owner `secrets: inherit` silently passes an empty token,
+# so the reviewer dies with "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN,
+# ... is required". Keep this file named claude-code-review.yml so claude.yml
 # can re-dispatch a review after an @claude run pushes commits.
 name: Claude Code Review
 
@@ -22,7 +27,11 @@ jobs:
       issues: write
       id-token: write
     uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
-    secrets: inherit
+    # Pass secrets explicitly — cross-owner `secrets: inherit` drops them (see
+    # the header comment). SUBMODULES_TOKEN is optional (empty when unset).
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}
     with:
       # Wires the workflow_dispatch input through so claude.yml can re-dispatch a
       # review on Claude's commits; empty (and ignored) for pull_request runs.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 # Calls the shared reusable Claude Code workflow in d-morrison/gha.
-# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret, passed EXPLICITLY
-# (not `secrets: inherit`): the reusable workflow is in the d-morrison *user*
-# account while this repo is in the *UCD-SERG org*, and cross-owner `inherit`
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret, passed explicitly
+# (not `secrets: inherit`): the reusable workflow is in the d-morrison user
+# account while this repo is in the UCD-SERG org, and cross-owner `inherit`
 # silently passes an empty token. SUBMODULES_TOKEN / WORKFLOW_TOKEN are
 # optional and resolve to empty when unset.
 name: Claude Code

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,9 @@
 # Calls the shared reusable Claude Code workflow in d-morrison/gha.
-# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret; `secrets: inherit`
-# passes it (and any optional WORKFLOW_TOKEN) through to the reusable workflow.
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret, passed EXPLICITLY
+# (not `secrets: inherit`): the reusable workflow is in the d-morrison *user*
+# account while this repo is in the *UCD-SERG org*, and cross-owner `inherit`
+# silently passes an empty token. SUBMODULES_TOKEN / WORKFLOW_TOKEN are
+# optional and resolve to empty when unset.
 name: Claude Code
 
 on:
@@ -31,7 +34,13 @@ jobs:
       id-token: write
       actions: write       # dispatch the review workflow via `gh workflow run`
     uses: d-morrison/gha/.github/workflows/claude.yml@v1
-    secrets: inherit
+    # Pass secrets explicitly — cross-owner `secrets: inherit` drops them (see
+    # the header comment). SUBMODULES_TOKEN / WORKFLOW_TOKEN are optional and
+    # resolve to empty when unset.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
     with:
       # The lab manual is a Quarto book, so Claude needs Quarto to render
       # chapters. Dependencies are installed from DESCRIPTION as RSPM binaries


### PR DESCRIPTION
Fixes the broken @claude **reviewer** and **assistant** on this repo.

## Root cause
`secrets: inherit` only passes secrets into a reusable workflow owned by the **same org/user**. The shared workflows are in **`d-morrison/gha`** (a user account); this repo is in the **`UCD-SERG` org** — a different owner. So `inherit` resolved `CLAUDE_CODE_OAUTH_TOKEN` to `""` and every `@claude` run failed env-validation. Confirmed from the run log (`"claude_code_oauth_token": ""`) and verified the fix (token → `***`) by experiment.

## Change
Both caller stubs (`claude.yml`, `claude-code-review.yml`) now pass secrets **explicitly** instead of `secrets: inherit`, plus corrected header comments explaining why.

## Verification
- YAML parses; explicit-passing experiment showed the token arrives non-empty.
- ⚠️ This PR's **own** `@claude` review will still fail — `pull_request` workflows run from the **base branch** (`main`), which still has the broken `inherit`. The fix self-applies only **after merge**. So this one bootstraps on green CI + author review.

Canonical fix to the `d-morrison/gha` example stubs/docs is tracked separately so other consumer repos pick up the working pattern.

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)