### PR TITLE
Transclude ai-config shared/ guidance fragments

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -15,6 +15,20 @@ This makes those reusable skills available as **project skills** to:
   skills from `.claude/skills/` in the checked-out repo. The workflow's checkout
   step uses `submodules: recursive` so the submodule is populated in CI.
 
+## `shared/` guidance fragments transcluded into the book
+
+The submodule also carries `ai-config`'s `shared/` directory: small,
+single-topic guidance fragments (coding style, writing style, PR/agent
+workflow) that this book transcludes with `{{< include
+.ai-config/shared/<topic>.md >}}`. The fragment is the single source of truth,
+shared with `ai-config`'s own `CLAUDE.md`, so the guidance is edited once and
+appears in both places.
+
+Because the render now depends on the submodule, the Quarto build workflows
+(`publish.yml`, `preview.yml`) check out submodules too --- not just the
+`@claude` workflows. Render locally only after
+`git submodule update --init --recursive`.
+
 ### Populating the submodule after cloning
 
 A plain `git clone` leaves the submodule empty and the symlink dangling. Run:

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -15,6 +15,27 @@ This makes those reusable skills available as **project skills** to:
   skills from `.claude/skills/` in the checked-out repo. The workflow's checkout
   step uses `submodules: recursive` so the submodule is populated in CI.
 
+### Populating the submodule after cloning
+
+A plain `git clone` leaves the submodule empty and the symlink dangling. Run:
+
+```sh
+git submodule update --init --recursive
+```
+
+(or clone with `git clone --recurse-submodules`).
+
+### Updating to a newer ai-config
+
+The submodule is pinned to a specific `ai-config` commit. To bump it:
+
+```sh
+git -C .ai-config fetch origin
+git -C .ai-config checkout origin/main
+git add .ai-config
+git commit -m "Bump .ai-config submodule"
+```
+
 ## `shared/` guidance fragments transcluded into the book
 
 The submodule also carries `ai-config`'s `shared/` directory: small,
@@ -28,24 +49,3 @@ Because the render now depends on the submodule, the Quarto build workflows
 (`publish.yml`, `preview.yml`) check out submodules too --- not just the
 `@claude` workflows. Render locally only after
 `git submodule update --init --recursive`.
-
-### Populating the submodule after cloning
-
-A plain `git clone` leaves the submodule empty and the symlink dangling. Run:
-
-```sh
-git submodule update --init --recursive
-```
-
-(or clone with `git clone --recurse-submodules`).
-
-### Updating to newer skills
-
-The submodule is pinned to a specific `ai-config` commit. To bump it:
-
-```sh
-git -C .ai-config fetch origin
-git -C .ai-config checkout origin/main
-git add .ai-config
-git commit -m "Bump .ai-config submodule"
-```

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch full history for git diff
+          # Populate the .ai-config submodule so chapters can {{< include >}}
+          # its shared/ guidance fragments at render time. ai-config is public,
+          # so no token is needed.
+          submodules: recursive
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Populate the .ai-config submodule so chapters can {{< include >}}
+          # its shared/ guidance fragments at render time. ai-config is public,
+          # so no token is needed.
+          submodules: recursive
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -103,3 +103,33 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 ### Reviewing a Copilot PR You Didn't Create
 
 {{< include ai-tools/reviewing-copilot-prs.qmd >}}
+
+## Pull-Request Workflow with Agents
+
+The practices below apply whether you are driving an agent's work or doing the
+work yourself. They keep parallel sessions from colliding and keep a pull
+request moving toward a clean, mergeable state.
+
+### File an Issue Before Starting
+
+{{< include .ai-config/shared/workflow/issue-first.md >}}
+
+### Claim a PR or Issue Before Working on It
+
+{{< include .ai-config/shared/workflow/claim-pr.md >}}
+
+### Keep Your Branch Synced with Main
+
+{{< include .ai-config/shared/workflow/sync-with-main.md >}}
+
+### Driving a Pull Request to Clean
+
+{{< include .ai-config/shared/workflow/ardi.md >}}
+
+### What "Fully Clean" Means {#sec-fully-clean}
+
+{{< include .ai-config/shared/workflow/fully-clean.md >}}
+
+### Address Every In-Scope Review Comment
+
+{{< include .ai-config/shared/workflow/address-every-comment.md >}}

--- a/coding-style.qmd
+++ b/coding-style.qmd
@@ -12,6 +12,10 @@ Follow these code style guidelines for all R code:
 
 {{< include coding-style/function-structure-and-documentation.qmd >}}
 
+## Avoiding Deep Nesting {#sec-avoid-nesting}
+
+{{< include .ai-config/shared/coding/avoid-nesting.md >}}
+
 ## Comments
 
 {{< include coding-style/comments.qmd >}}

--- a/writing.qmd
+++ b/writing.qmd
@@ -11,6 +11,6 @@
 ## Scanning for AI Tells {#sec-ai-tells}
 
 When AI tools draft or edit prose, the result often carries telltale signs of
-machine authorship. Scan for them before sending:
+machine authorship:
 
 {{< include .ai-config/shared/writing/ai-tells.md >}}

--- a/writing.qmd
+++ b/writing.qmd
@@ -3,3 +3,14 @@
 ## Writing to Clarify Your Thinking
 
 {{< include writing/writing-to-clarify-thinking.qmd >}}
+
+## Plain, Direct Prose {#sec-plain-prose}
+
+{{< include .ai-config/shared/writing/plain-prose.md >}}
+
+## Scanning for AI Tells {#sec-ai-tells}
+
+When AI tools draft or edit prose, the result often carries telltale signs of
+machine authorship. Scan for them before sending:
+
+{{< include .ai-config/shared/writing/ai-tells.md >}}

--- a/writing.qmd
+++ b/writing.qmd
@@ -11,6 +11,6 @@
 ## Scanning for AI Tells {#sec-ai-tells}
 
 When AI tools draft or edit prose, the result often carries telltale signs of
-machine authorship:
+machine authorship.
 
 {{< include .ai-config/shared/writing/ai-tells.md >}}


### PR DESCRIPTION
Closes #328.

## What

Transcludes shared guidance from the `.ai-config` submodule into the book with
`{{< include .ai-config/shared/<topic>.md >}}`, so coding style, writing style,
and PR/agent workflow guidance live in both the lab manual and `ai-config`'s
`CLAUDE.md` from one source of truth.

| Chapter | New section(s) | Fragment |
| --- | --- | --- |
| `coding-style.qmd` | Avoiding Deep Nesting | `coding/avoid-nesting.md` |
| `writing.qmd` | Plain, Direct Prose; Scanning for AI Tells | `writing/plain-prose.md`, `writing/ai-tells.md` |
| `ai-tools.qmd` | Pull-Request Workflow with Agents | `workflow/issue-first.md`, `claim-pr.md`, `sync-with-main.md`, `ardi.md`, `fully-clean.md`, `address-every-comment.md` |

## Render now needs the submodule

The book render now depends on `.ai-config` being checked out, so `publish.yml`
and `preview.yml` gain `submodules: recursive` (previously only the `@claude`
workflows checked out submodules). Render locally only after
`git submodule update --init --recursive`.

## Verification

- `quarto render writing.qmd` succeeds; the rendered HTML contains the fragment
  text ("Principles of Scientific Writing", "delve", "subordinate"), confirming
  the includes resolve.
- `check-non-standard-chars.py` passes (126 files); fragments are ASCII.

## Dependency

The `.ai-config` pointer is bumped to the `ai-config` branch commit that adds
`shared/` (d-morrison/ai-config#96). After that PR merges, re-pin `.ai-config`
to the resulting `main` commit. The eventual two-way auto-PR tracking will keep
this current automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2VtR2kJXS6QZHnggCTb4M)_