### PR TITLE
docs(ai-tools): add Windows install notes for Claude Code (re-creates #301)

### DIFF
--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -104,6 +104,6 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/reviewing-copilot-prs.qmd >}}
 
-### Installing Claude Code on Windows {#sec-claude-code-windows}
+### Installing Claude Code on Windows {#sec-ai-claude-code-windows}
 
 {{< include ai-tools/installing-claude-code-windows.qmd >}}

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -103,3 +103,7 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 ### Reviewing a Copilot PR You Didn't Create
 
 {{< include ai-tools/reviewing-copilot-prs.qmd >}}
+
+### Installing Claude Code on Windows {#sec-claude-code-windows}
+
+{{< include ai-tools/installing-claude-code-windows.qmd >}}

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -25,6 +25,8 @@ If you use WSL,
 install Claude Code *inside* WSL---
 a Windows install will not carry over,
 because WSL has its own filesystem and `PATH`.
+Inside WSL the standard Linux install applies,
+and the Windows-specific `PATH` and `rehash` gotchas below don't apply.
 
 #### Install Claude Code
 
@@ -37,6 +39,9 @@ There are two common routes:
    ```
 
    This installs the binary to `~/.local/bin`.
+   If your organization's policy requires it,
+   download and inspect the script before running it
+   rather than piping it straight to `bash`.
 
 2. **npm** (requires [Node.js](https://nodejs.org/)):
 
@@ -75,7 +80,7 @@ export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Note that `$HOME` differs by shell:
-in **Git Bash** it is `C:\Users\<you>` (where the installer puts the binary),
+in **Git Bash** it is `/c/Users/<you>` (your Windows user profile, where the installer puts the binary),
 but in **MSYS2** it is `/home/<you>`.
 If they differ on your machine,
 use the absolute Windows path so MSYS2 finds the real install:
@@ -144,7 +149,7 @@ winpty gh auth login
 Open a **new** terminal window (so it picks up your updated config) and run:
 
 ```sh
-claude --version      # e.g. 2.1.177 (Claude Code)
+claude --version      # prints the installed version number
 ```
 
 If you get a version number, you're ready to run `claude` in your project directory.

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -55,7 +55,7 @@ There are two common routes:
 Even if you install via npm,
 current versions **migrate themselves to a native install**
 the first time you run `claude`
-(at `~/.local/bin/claude`, or `claude.exe` on Windows)
+(at `~/.local/bin/claude`, or `~/.local/bin/claude.exe` on Windows)
 and remove the npm copy.
 
 This is the single most confusing Windows gotcha:
@@ -123,21 +123,22 @@ bash: $'\377\376export': command not found
 ```
 
 Edit dotfiles from *inside* the shell
-(e.g. with `nano`, `vim`, or `echo … >> ~/.zshrc` run in bash/zsh),
+(e.g. with `nano`, `vim`, or `echo 'export PATH=...' >> ~/.zshrc` run in bash/zsh),
 or with an editor that saves UTF-8 without a BOM (e.g. VS Code).
 :::
 
-#### Authenticating the GitHub CLI in Git Bash
+#### Authenticating the GitHub CLI in Git Bash or MSYS2
 
 If you also use the [GitHub CLI](https://cli.github.com/) (`gh`)
 to push code or open pull requests,
-`gh auth login` may fail in Git Bash with:
+`gh auth login` may fail with:
 
 ```
 could not prompt: … running in MinTTY without pseudo terminal support
 ```
 
-Git Bash's terminal (MinTTY) can't host the interactive prompt.
+Git Bash and MSYS2 both default to the MinTTY terminal,
+which can't host the interactive prompt.
 Wrap the command with `winpty`,
 or run it from PowerShell / Windows Terminal instead:
 

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -1,0 +1,154 @@
+[Claude Code](https://www.anthropic.com/claude-code) is Anthropic's
+command-line coding agent.
+Installing it on Windows works well,
+but a few platform-specific pitfalls can cost you hours if you don't know about them.
+These notes capture a setup that works,
+and the gotchas to watch for.
+
+::: {.callout-note}
+These notes were written in June 2026.
+As with the rest of this chapter,
+treat the specifics with caution---
+installers and behavior change quickly.
+:::
+
+#### Run it from a Unix-like terminal
+
+Claude Code expects a Unix-like shell.
+On Windows, run it from one of:
+
+- **Git Bash** (ships with [Git for Windows](https://gitforwindows.org/));
+- **MSYS2** (<https://www.msys2.org/>), which also gives you a package manager (`pacman`) and optional `zsh`;
+- **WSL** (Windows Subsystem for Linux), the most Unix-faithful option.
+
+If you use WSL,
+install Claude Code *inside* WSL---
+a Windows install will not carry over,
+because WSL has its own filesystem and `PATH`.
+
+#### Install Claude Code
+
+There are two common routes:
+
+1. **Native installer** (recommended):
+
+   ```sh
+   curl -fsSL https://claude.ai/install.sh | bash
+   ```
+
+   This installs the binary to `~/.local/bin`.
+
+2. **npm** (requires [Node.js](https://nodejs.org/)):
+
+   ```sh
+   npm install -g @anthropic-ai/claude-code
+   ```
+
+::: {.callout-important}
+## Claude Code migrates itself out of npm
+
+Even if you install via npm,
+the first time you run `claude` it **migrates itself to a native install**
+at `~/.local/bin/claude` (`claude.exe` on Windows)
+and removes the npm copy.
+
+This is the single most confusing Windows gotcha:
+a path that worked a moment ago "disappears."
+**Do not** hardcode the npm location
+(e.g. `…/AppData/Roaming/npm/…`) in your shell config.
+Point your `PATH` at `~/.local/bin` instead.
+:::
+
+#### Make sure your shell can find `claude`
+
+The native binary lives in `~/.local/bin`.
+The installer adds this directory to `PATH` for ordinary shells,
+but on Windows two things commonly break that.
+
+**MSYS2 does not inherit the Windows `PATH` by default.**
+It starts in a "minimal" path mode,
+so tools installed elsewhere on Windows are invisible to it.
+Add the binary's directory explicitly in your `~/.zshrc` (or `~/.bashrc`):
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Note that `$HOME` differs by shell:
+in **Git Bash** it is `C:\Users\<you>` (where the installer puts the binary),
+but in **MSYS2** it is `/home/<you>`.
+If they differ on your machine,
+use the absolute Windows path so MSYS2 finds the real install:
+
+```sh
+export PATH="/c/Users/<you>/.local/bin:$PATH"
+```
+
+**Rehash after changing `PATH`.**
+`zsh` and `bash` cache the locations of executables.
+If you add a directory to `PATH` in your shell config,
+the shell may still report `command not found`
+*even though the directory is on `PATH`*,
+because its command table is stale.
+Force a rebuild right after the export:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+rehash        # zsh; use 'hash -r' in bash
+```
+
+This bites hardest with [oh-my-zsh](https://ohmyz.sh/),
+which builds zsh's command table *before* your custom `PATH` line runs,
+so without the `rehash` you will see `command not found`
+no matter how many times you open a new window.
+
+#### Do not edit dotfiles with PowerShell redirection
+
+::: {.callout-warning}
+## PowerShell writes the wrong encoding
+
+Never write to `~/.bashrc`, `~/.zshrc`, or other shell config files
+using PowerShell's `>` or `>>` redirection.
+Windows PowerShell writes **UTF-16 with a byte-order mark**,
+which `bash`/`zsh` read as a stray character at the start of the file:
+
+```
+bash: $'\377\376export': command not found
+```
+
+Edit dotfiles from *inside* the shell
+(e.g. with `nano`, `vim`, or `echo … >> ~/.zshrc` run in bash/zsh),
+or with an editor that saves UTF-8 without a BOM (e.g. VS Code).
+:::
+
+#### Authenticating the GitHub CLI in Git Bash
+
+If you also use the [GitHub CLI](https://cli.github.com/) (`gh`)
+to push code or open pull requests,
+`gh auth login` may fail in Git Bash with:
+
+```
+could not prompt: … running in MinTTY without pseudo terminal support
+```
+
+Git Bash's terminal (MinTTY) can't host the interactive prompt.
+Wrap the command with `winpty`,
+or run it from PowerShell / Windows Terminal instead:
+
+```sh
+winpty gh auth login
+```
+
+#### Verify the install
+
+Open a **new** terminal window (so it picks up your updated config) and run:
+
+```sh
+claude --version      # e.g. 2.1.177 (Claude Code)
+```
+
+If you get a version number, you're ready to run `claude` in your project directory.
+If you get `command not found`,
+re-check the two `PATH` issues above:
+the directory must be on `PATH`,
+and you must `rehash` (or open a fresh window) after changing it.

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -61,7 +61,7 @@ This is the single most confusing Windows gotcha:
 a path that worked a moment ago "disappears."
 **Do not** hardcode the npm location
 (e.g. `…/AppData/Roaming/npm/…`) in your shell config.
-Point your `PATH` at `~/.local/bin` instead.
+Point your `PATH` at the shell-appropriate directory shown in the next section instead.
 :::
 
 #### Make sure your shell can find `claude`

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -50,12 +50,13 @@ There are two common routes:
    ```
 
 ::: {.callout-important}
-## Claude Code migrates itself out of npm
+#### Claude Code migrates itself out of npm
 
 Even if you install via npm,
-the first time you run `claude` it **migrates itself to a native install**
-at `~/.local/bin/claude` (`claude.exe` on Windows)
-and removes the npm copy.
+current versions **migrate themselves to a native install**
+the first time you run `claude`
+(at `~/.local/bin/claude`, or `claude.exe` on Windows)
+and remove the npm copy.
 
 This is the single most confusing Windows gotcha:
 a path that worked a moment ago "disappears."
@@ -103,13 +104,14 @@ rehash        # zsh; use 'hash -r' in bash
 
 This bites hardest with [oh-my-zsh](https://ohmyz.sh/),
 which builds zsh's command table *before* your custom `PATH` line runs,
-so without the `rehash` you will see `command not found`
-no matter how many times you open a new window.
+so opening a fresh window may not clear the stale `command not found`
+on its own until you `rehash` (or move the `PATH` line before oh-my-zsh
+initializes).
 
 #### Do not edit dotfiles with PowerShell redirection
 
 ::: {.callout-warning}
-## PowerShell writes the wrong encoding
+#### PowerShell writes the wrong encoding
 
 Never write to `~/.bashrc`, `~/.zshrc`, or other shell config files
 using PowerShell's `>` or `>>` redirection.

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -149,6 +149,9 @@ or run it from PowerShell / Windows Terminal instead:
 winpty gh auth login
 ```
 
+`winpty` ships with Git Bash, but in MSYS2 it's a separate package ---
+install it first with `pacman -S winpty` if you get `command not found`.
+
 #### Verify the install
 
 Open a **new** terminal window (so it picks up your updated config) and run:

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -57,11 +57,14 @@ current versions **migrate themselves to a native install**
 the first time you run `claude`
 (at `~/.local/bin/claude`, or `~/.local/bin/claude.exe` on Windows)
 and remove the npm copy.
+You can watch this happen in the terminal output the first time you run
+`claude`; the current install methods are documented in the
+[Claude Code setup guide](https://code.claude.com/docs/en/setup).
 
 This is the single most confusing Windows gotcha:
 a path that worked a moment ago "disappears."
 **Do not** hardcode the npm location
-(e.g. `…/AppData/Roaming/npm/…`) in your shell config.
+(e.g. `.../AppData/Roaming/npm/...`) in your shell config.
 Point your `PATH` at the shell-appropriate directory shown in the next section instead.
 :::
 

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -95,10 +95,9 @@ If you add a directory to `PATH` in your shell config,
 the shell may still report `command not found`
 *even though the directory is on `PATH`*,
 because its command table is stale.
-Force a rebuild right after the export:
+Force a rebuild in the same shell right after editing `PATH`:
 
 ```sh
-export PATH="$HOME/.local/bin:$PATH"
 rehash        # zsh; use 'hash -r' in bash
 ```
 

--- a/ai-tools/installing-claude-code-windows.qmd
+++ b/ai-tools/installing-claude-code-windows.qmd
@@ -73,20 +73,20 @@ but on Windows two things commonly break that.
 **MSYS2 does not inherit the Windows `PATH` by default.**
 It starts in a "minimal" path mode,
 so tools installed elsewhere on Windows are invisible to it.
-Add the binary's directory explicitly in your `~/.zshrc` (or `~/.bashrc`):
+Add the binary's directory explicitly in your `~/.zshrc` (or `~/.bashrc`).
+Because MSYS2's `$HOME` is `/home/<you>` (its own home, not the Windows
+profile where the installer puts the binary),
+point `PATH` at the absolute Windows path:
 
 ```sh
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="/c/Users/<you>/.local/bin:$PATH"     # MSYS2
 ```
 
-Note that `$HOME` differs by shell:
-in **Git Bash** it is `/c/Users/<you>` (your Windows user profile, where the installer puts the binary),
-but in **MSYS2** it is `/home/<you>`.
-If they differ on your machine,
-use the absolute Windows path so MSYS2 finds the real install:
+In **Git Bash**, `$HOME` already is `/c/Users/<you>` (your Windows user
+profile), so the shorthand works there:
 
 ```sh
-export PATH="/c/Users/<you>/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"     # Git Bash
 ```
 
 **Rehash after changing `PATH`.**


### PR DESCRIPTION
Adds a Windows-specific install guide for **Claude Code** to the AI tools chapter, as a new subsection under *Coding Agents*.

## Why

Installing Claude Code on Windows has several non-obvious pitfalls that can cost hours:

- Claude Code **self-migrates out of npm** to `~/.local/bin` on first run (paths "disappear").
- **MSYS2 doesn't inherit the Windows `PATH`** by default.
- You must **`rehash`** (zsh) / **`hash -r`** (bash) after changing `PATH` — especially with oh-my-zsh.
- **Don't edit dotfiles with PowerShell `>`/`>>`** (UTF-16 BOM breaks bash/zsh).
- `gh auth login` in Git Bash needs **`winpty`**.

## Changes

- New partial: `ai-tools/installing-claude-code-windows.qmd`
- New subsection "Installing Claude Code on Windows" wired into `ai-tools.qmd`

## Provenance

This re-creates the content of #301 by @dem-extra1 (originally from an external fork that couldn't be pushed to from automation) on an in-repo branch off current `main`, so it can be synced and driven to a clean, mergeable state. Authorship is preserved via `Co-Authored-By`. Once this is merged, **#301 can be closed as superseded**.

Verified: the changed files pass `check-non-standard-chars.py` (the `…` ellipses are inside code spans and are not among the flagged characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSXQ1h5cKb834kahzzF4MB)_