### PR TITLE
Extract prompt-formats + Copilot-review guidance to shared/ fragments

### DIFF
--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -54,7 +54,7 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 ### Useful Prompt Formats
 
-{{< include ai-tools/useful-prompt-formats.qmd >}}
+{{< include shared/prompt-formats.md >}}
 
 ### Addressing Failing GitHub Actions Workflows {#sec-ai-addressing-failing-workflows}
 
@@ -98,7 +98,7 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 ### Using Copilot Review Before Human Review
 
-{{< include ai-tools/copilot-review-before-human-review.qmd >}}
+{{< include shared/copilot-review-before-human.md >}}
 
 ### Reviewing a Copilot PR You Didn't Create
 

--- a/shared/copilot-review-before-human.md
+++ b/shared/copilot-review-before-human.md
@@ -14,30 +14,30 @@ saving everyone time and improving code quality.
 
 **Copilot review workflow:**
 
-1. **Assign Copilot as a reviewer**: 
+1. **Assign Copilot as a reviewer**:
    On your pull request page,
    assign Copilot to review the PR the same way you would assign any other reviewer.
    Click "Reviewers" in the right sidebar and select Copilot from the list.
 
-2. **Review Copilot's comments**: 
+2. **Review Copilot's comments**:
    Once Copilot completes its review,
    carefully examine each comment.
    For each comment, decide whether you agree with the suggestion:
-   
+
    - **If the comment is correct**: Address it by making code changes yourself or ask Copilot to apply the fix using GitHub's suggestion features
    - **If the comment is incorrect or not applicable**: Dismiss the comment with an explanation for why it doesn't apply
    - **If you're uncertain**: Seek a second opinion from a human reviewer or do additional research
 
-3. **Request another Copilot review**: 
+3. **Request another Copilot review**:
    After addressing or dismissing all comments,
    request another review from Copilot.
    This creates an iterative improvement process.
 
-4. **Iterate until satisfied**: 
+4. **Iterate until satisfied**:
    Repeat the review-and-address cycle until Copilot stops providing valuable suggestions.
    This typically takes 1-3 iterations depending on the complexity of the changes.
 
-5. **Request human review**: 
+5. **Request human review**:
    Only after you've addressed Copilot's feedback should you request review from human team members.
    At this point,
    the code should be in better shape,

--- a/shared/prompt-formats.md
+++ b/shared/prompt-formats.md
@@ -1,4 +1,3 @@
-
 When working with coding agents,
 using clear and specific prompts helps achieve better results.
 Here are some useful prompt formats that you can use when requesting assistance from coding agents:


### PR DESCRIPTION
## What

Moves two audience-neutral `ai-tools/` chapter fragments into a new top-level `shared/` directory as plain markdown:

- `ai-tools/useful-prompt-formats.qmd` -> `shared/prompt-formats.md`
- `ai-tools/copilot-review-before-human-review.qmd` -> `shared/copilot-review-before-human.md`

`ai-tools.qmd` now includes the `.md` fragments directly, and the intermediate `.qmd` files are removed.

## Why

This is the **manual -> ai-config** direction of the two-way sync started in #329. ai-config already flows its `shared/` fragments into this book via the `.ai-config` submodule; these two fragments go the other way, so `d-morrison/ai-config` can vendor a pinned copy and `@`-import them into `CLAUDE.md`. Keeping them ASCII and Quarto-construct-free (they already are) lets ai-config consume them as plain markdown.

`shared/` (this repo's own fragments) sits alongside `.ai-config/shared/` (the submodule's fragments) — the two directions of the same sync.

## Notes

- Content is unchanged — a verbatim move. `check-non-standard-chars` passes; the fragments are pure ASCII.
- Follow-ups (tracked in #331): ai-config vendors a pinned copy + drift-check (Phase 3b); a scheduled auto-PR keeps the copy fresh (Phase 4).

Closes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2VtR2kJXS6QZHnggCTb4M)_