### PR TITLE
Add scheduled .ai-config submodule auto-bump

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -27,7 +27,10 @@ git submodule update --init --recursive
 
 ### Updating to a newer ai-config
 
-The submodule is pinned to a specific `ai-config` commit. To bump it:
+The submodule is pinned to a specific `ai-config` commit. The `Bump .ai-config`
+workflow (`.github/workflows/bump-ai-config.yml`) advances it to `ai-config`'s
+`main` weekly and opens a PR when the pointer moves, so this usually happens on
+its own. To bump it by hand:
 
 ```sh
 git -C .ai-config fetch origin

--- a/.github/workflows/bump-ai-config.yml
+++ b/.github/workflows/bump-ai-config.yml
@@ -1,0 +1,22 @@
+# Auto-bump the .ai-config submodule to ai-config's main, opening a PR when the
+# pointer moves. Calls d-morrison/gha's reusable bump-submodule workflow.
+#
+# .ai-config is public, so no SUBMODULES_TOKEN is needed, and the PR is opened in
+# this repo with the integrated GITHUB_TOKEN -- which requires Settings ->
+# Actions -> General -> "Allow GitHub Actions to create and approve pull
+# requests" to be enabled.
+name: Bump .ai-config
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: d-morrison/gha/.github/workflows/bump-submodule.yml@v1
+    with:
+      submodule-path: .ai-config


### PR DESCRIPTION
## What

Adds `.github/workflows/bump-ai-config.yml` — a scheduled caller for `d-morrison/gha`'s new `bump-submodule` reusable workflow (now at `@v1`). It advances `.ai-config` to `ai-config`'s `main` weekly (and on `workflow_dispatch`) and opens a PR when the pointer moves. Also notes the auto-bump in `.claude/README.md`.

## Why

This is the **lab-manual half** of the two-way shared-content sync. `.ai-config`'s pinned commit drifts behind `ai-config`'s `main` until someone bumps it by hand; this keeps it current automatically. (The ai-config half — refreshing the vendored copies of this repo's fragments — is a sibling PR.)

## Notes

- `.ai-config` is public, so no `SUBMODULES_TOKEN` is needed.
- **Repo setting required:** the PR is opened with the integrated `GITHUB_TOKEN`, so **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** must be enabled, or the bump step will fail to open the PR.
- The `schedule` trigger only takes effect once this is on `main`.

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2VtR2kJXS6QZHnggCTb4M)_