### PR TITLE
Add "Responding to review comments" subsection to Code Review

### DIFF
--- a/communication.qmd
+++ b/communication.qmd
@@ -132,8 +132,7 @@ When a reviewer leaves a comment on your code, respond to each one with exactly 
 
 - **Address it.** Make the change the reviewer asked for.
 - **Rebut it.** If you think the code is correct as written, explain your reasoning and push back. You are entitled to disagree, as long as you say why.
-- **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply so the reviewer can see the work will not be lost.
+- **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply. This keeps the work visible and ensures it is not lost.
+- **Acknowledge it.** For an observation that requests no change, a short acknowledgement is enough.
 
-For an observation that requests no change, a short acknowledgement is enough.
-
-Silently ignoring a review comment is not a valid option. Leaving a comment unanswered stalls the review and signals that you missed it or chose not to engage. Always reply, even if only to say you have filed a follow-up issue.
+Never ignore a review comment. Always reply --- even if only to say you filed a follow-up issue.

--- a/communication.qmd
+++ b/communication.qmd
@@ -133,10 +133,10 @@ respond to each one with exactly one of these:
 
 - **Address it.** Make the change the reviewer asked for.
 - **Rebut it.** If you think the code is correct as written, explain your reasoning and push back.
-  You are entitled to disagree, as long as you say why.
+  You can disagree---just say why.
 - **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply.
   This keeps the work visible and ensures it is not lost.
-- **Acknowledge it.** For an observation that requests no change, a short acknowledgement is enough.
+- **Acknowledge it.** For a comment that needs no action, a short acknowledgment is enough.
 
 Never ignore a review comment.
 Always reply---even if only to say you filed a follow-up issue.

--- a/communication.qmd
+++ b/communication.qmd
@@ -124,4 +124,16 @@ This allows you to check the room's availability before scheduling.
 
 When submitting code to or reviewing code from colleagues, use best practices to provide and receive constructive feedback:
 
-- [Tidyverse code review principles](https://code-review.tidyverse.org/) [@tidyverse2023codereview]: Best practices for reviewing R code, including what to look for and how to provide constructive feedback. 
+- [Tidyverse code review principles](https://code-review.tidyverse.org/) [@tidyverse2023codereview]: Best practices for reviewing R code, including what to look for and how to provide constructive feedback.
+
+### Responding to review comments
+
+When a reviewer leaves a comment on your code, respond to each one with exactly one of these:
+
+- **Address it.** Make the change the reviewer asked for.
+- **Rebut it.** If you think the code is correct as written, explain your reasoning and push back. You are entitled to disagree, as long as you say why.
+- **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply so the reviewer can see the work will not be lost.
+
+For an observation that requests no change, a short acknowledgement is enough.
+
+Silently ignoring a review comment is not a valid option. Leaving a comment unanswered stalls the review and signals that you missed it or chose not to engage. Always reply, even if only to say you have filed a follow-up issue.

--- a/communication.qmd
+++ b/communication.qmd
@@ -128,11 +128,15 @@ When submitting code to or reviewing code from colleagues, use best practices to
 
 ### Responding to review comments
 
-When a reviewer leaves a comment on your code, respond to each one with exactly one of these:
+When a reviewer leaves a comment on your code,
+respond to each one with exactly one of these:
 
 - **Address it.** Make the change the reviewer asked for.
-- **Rebut it.** If you think the code is correct as written, explain your reasoning and push back. You are entitled to disagree, as long as you say why.
-- **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply. This keeps the work visible and ensures it is not lost.
+- **Rebut it.** If you think the code is correct as written, explain your reasoning and push back.
+  You are entitled to disagree, as long as you say why.
+- **Defer it.** If the comment is valid but out of scope for this change, file a tracking issue and link it in your reply.
+  This keeps the work visible and ensures it is not lost.
 - **Acknowledge it.** For an observation that requests no change, a short acknowledgement is enough.
 
-Never ignore a review comment. Always reply --- even if only to say you filed a follow-up issue.
+Never ignore a review comment.
+Always reply---even if only to say you filed a follow-up issue.


### PR DESCRIPTION
## What

Adds a new `### Responding to review comments` subsection under the **Code Review** section of `communication.qmd`. It summarizes the valid dispositions for a code-review comment:

- **Address it** — make the requested change.
- **Rebut it** — explain why the code is correct as-is; you may push back with reasoning.
- **Defer it** — when valid but out of scope, file a tracking issue and link it in your reply.

It also covers a short acknowledgement for no-change observations, and states plainly that silently ignoring a review comment is not a valid option.

## Where

`communication.qmd`, directly after the existing Tidyverse code-review link in the `## Code Review` section — the location the issue references (`communication.html#code-review`).

## Notes

- Scope kept tight to #313. No related-issue work (chapter splits, PR etiquette) included.
- No new spell-check terms needed; all wording is standard English.
- Edited page renders cleanly in isolation (`quarto render communication.qmd`). The full book render currently fails on a pre-existing missing-include in `coding-style.qmd`, unrelated to this change.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VEkiDdAYm9tMNpJNbX1ai)_