### PR TITLE
Add "Template repositories" section to Code repositories chapter

### DIFF
--- a/code-repositories.qmd
+++ b/code-repositories.qmd
@@ -4,8 +4,12 @@ Adapted by UCD-SeRG team from [original by Kunal Mishra, Jade Benjamin-Chung, an
 
 Each study has at least one code repository that typically holds R code, shell scripts with Unix code, and research outputs (results .RDS files, tables, figures). Repositories may also include datasets. This chapter outlines how to organize these files. Adhering to a standard format makes it easier for us to efficiently collaborate across projects. 
 
-UCD-SeRG projects use R package structure for most R-based work. 
+UCD-SeRG projects use R package structure for most R-based work.
 This provides benefits for reproducibility, collaboration, and code quality even for analysis-only projects.
+
+## Template repositories
+
+{{< include code-repositories/template-repositories.qmd >}}
 
 ## Package Structure
 

--- a/code-repositories/template-repositories.qmd
+++ b/code-repositories/template-repositories.qmd
@@ -1,0 +1,25 @@
+When starting a new package,
+begin from the lab's template repository
+([`UCD-SERG/rpt`](https://github.com/UCD-SERG/rpt))
+rather than an empty repository.
+On GitHub, click **Use this template** to create a new repository that already
+includes our standard structure, CI workflows, and documentation scaffolding.
+Then replace the placeholder package name, `Title`, and `Description` in
+`DESCRIPTION` with your project's details.
+
+### A note on GitLab
+
+GitHub-style template repositories do **not** have a direct equivalent in
+GitLab Community Edition (CE):
+
+- **Built-in project templates** (Rails, Node, and similar) ship with all
+  editions, including CE, but you cannot add your own to that list.
+- **Custom project templates** (instance- or group-level) --- the feature most
+  analogous to GitHub's template repositories --- are
+  [Premium/Ultimate tier](https://docs.gitlab.com/user/group/custom_project_templates/)
+  only, so they are unavailable in CE.
+- On CE, the practical workaround is to **fork** (or clone and re-push) a "seed"
+  project to start new work from it.
+
+In short: if the lab ever mirrors this workflow onto a self-managed GitLab CE
+instance, plan to either fork a seed repository or budget for a paid tier.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,8 +1,10 @@
 Aiemjoy
 Barratt
 Burkholderia
+CE
 Djajadi
 Drs
+GitLab
 Heitmann
 Kunal
 LeCun
@@ -12,6 +14,7 @@ NonCommercial
 Orientia
 Paratyphi
 Pokpongkiat
+Rails
 SERG
 SeRG
 Seroepidemiology


### PR DESCRIPTION
## What

Adds a new **Template repositories** section to the *Code repositories* chapter (`code-repositories.qmd`), placed right after the intro as the natural getting-started step before the package-structure details.

The section covers:

- Starting a new package from the lab template ([`UCD-SERG/rpt`](https://github.com/UCD-SERG/rpt)) via GitHub's **Use this template**, then replacing the placeholder `DESCRIPTION` fields.
- A note that GitHub-style template repositories have no direct equivalent in GitLab Community Edition (CE): built-in templates can't be extended, custom project templates are a Premium/Ultimate tier feature, and the CE workaround is to fork a "seed" project.

## Why

Converts [d-morrison/rpt#154](https://github.com/d-morrison/rpt/issues/154), which was filed in `rpt` so the content could be transferred to this repo. (Cross-repo closing keywords don't auto-close, so that issue will need to be closed manually once this merges.)

## How it follows repo conventions

- Decomposed into `code-repositories/template-repositories.qmd` and wired in with `{{< include >}}`, keeping the `##` heading in the chapter file per the chapter-include convention.
- ASCII-only (em dashes written as `---`, straight quotes); semantic line breaks in the new prose.
- Added `GitLab`, `Rails`, and `CE` to `inst/WORDLIST` for the spell-check.

## Verification

- `quarto render code-repositories.qmd --to html` succeeds and the new section appears in the output (the one `@sec-unix` crossref warning is pre-existing and only shows when rendering a single chapter in isolation).
- No new NEWS entry: this repo has no `NEWS.md` or news-check workflow (the issue's note about that conflated it with `rpt`'s CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABYjF8xSN3G1FduBpB6Gsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABYjF8xSN3G1FduBpB6Gsp)_