### PR TITLE
claude-code-review: grant actions: read so the reviewer can see CI status

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read   # lets the reviewer read CI status (github_ci MCP server)
     uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
     # Pass secrets explicitly — cross-owner `secrets: inherit` drops them (see
     # the header comment). SUBMODULES_TOKEN is optional (empty when unset).


### PR DESCRIPTION
## What

Add `actions: read` to the `review` job `permissions:` in `.github/workflows/claude-code-review.yml`.

## Why

Our caller pins the `d-morrison/gha` reusable review workflow at `@v1` with an explicit `permissions:` block that omitted `actions: read`, so the `@claude` reviewer skipped its `github_ci` MCP server and reviewed blind to CI status:

```
##[warning]The github_ci MCP server requires 'actions: read' permission.
Skipping CI server installation.
```

Read-only, one-line grant. Part of the cross-repo sweep tracked in d-morrison/gha#109 (root fix: d-morrison/gha#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZmotGQp32sLeSHbhT6P1v)_