### PR TITLE
Broaden .gitattributes: normalize all text files to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Auto-detect text files and normalize them to LF in the working tree on
+# checkout, regardless of each contributor's global git config.
+* text=auto eol=lf
+
 # Shell scripts must use LF line endings — a CRLF on the shebang line makes
 # the kernel look for "/bin/bash\r" and fail with "bad interpreter".
 *.sh text eol=lf


### PR DESCRIPTION
Closes #351.

Follows up the merged `*.sh text eol=lf` PR. Prepends `* text=auto eol=lf` so **all** text files — not just shell scripts — are forced to LF in the working tree on every checkout, regardless of each contributor's global git config. Non-shell scripts (e.g. `.github/scripts/*.py`) pick up CRLF in working checkouts too and break their shebangs the same way.

Verified zero renormalization churn: no committed blob changes.