### PR TITLE
docs(CLAUDE): note Spellcheck job skips the .ai-config submodule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ includes directly. That is separate from `.ai-config/shared/`.
 
 - Spellcheck (`check-spelling.yaml`, `insightsengineering/r-spellcheck-action`).
   Add genuine technical terms and names to `inst/WORDLIST`, one per line.
+  Note: this job checks out **without** the `.ai-config` submodule, so prose in
+  `.ai-config/shared/*.md` fragments is not scanned. Don't assume a word passes
+  just because it already appears in the rendered manual via a transcluded
+  fragment (e.g. "inspectable" in `avoid-nesting.md`). A new word you add to a
+  file in this repo must be dictionary-valid or listed in `inst/WORDLIST`.
 - Link check (`check-links.yml`, `lycheeverse/lychee-action`) over `.qmd`/`.md`/
   `.html`. Fix broken links; only add an exclusion to `lychee.toml` when a URL
   is valid for humans but trips the automated checker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,12 @@ includes directly. That is separate from `.ai-config/shared/`.
 
 - Spellcheck (`check-spelling.yaml`, `insightsengineering/r-spellcheck-action`).
   Add genuine technical terms and names to `inst/WORDLIST`, one per line.
-  Note: this job checks out **without** the `.ai-config` submodule, so prose in
-  `.ai-config/shared/*.md` fragments is not scanned. Don't assume a word passes
-  just because it already appears in the rendered manual via a transcluded
-  fragment (e.g. "inspectable" in `avoid-nesting.md`). A new word you add to a
-  file in this repo must be dictionary-valid or listed in `inst/WORDLIST`.
+  Note: this job checks out **without** the `.ai-config` submodule,
+  so prose in `.ai-config/shared/*.md` fragments is not scanned.
+  Don't assume a word passes just because it already appears in the rendered
+  manual via a transcluded fragment (e.g. "inspectable" in `avoid-nesting.md`).
+  A new word you add to a file in this repo must be dictionary-valid
+  or listed in `inst/WORDLIST`.
 - Link check (`check-links.yml`, `lycheeverse/lychee-action`) over `.qmd`/`.md`/
   `.html`. Fix broken links; only add an exclusion to `lychee.toml` when a URL
   is valid for humans but trips the automated checker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,9 @@ includes directly. That is separate from `.ai-config/shared/`.
 - Spellcheck (`check-spelling.yaml`, `insightsengineering/r-spellcheck-action`).
   Add genuine technical terms and names to `inst/WORDLIST`, one per line.
   Note: this job checks out **without** the `.ai-config` submodule,
-  so prose in `.ai-config/shared/*.md` fragments is not scanned.
-  Don't assume a word passes just because it already appears in the rendered
-  manual via a transcluded fragment (e.g. "inspectable" in `avoid-nesting.md`).
+  so prose in `.ai-config/shared/**/*.md` fragments is not scanned.
+  Don't assume a word passes just because it already appears in the rendered manual
+  via a transcluded fragment (e.g. "inspectable" in `avoid-nesting.md`).
   A new word you add to a file in this repo must be dictionary-valid
   or listed in `inst/WORDLIST`.
 - Link check (`check-links.yml`, `lycheeverse/lychee-action`) over `.qmd`/`.md`/


### PR DESCRIPTION
## Why

While working #243 / #356, "inspectable" (used only in the transcluded
`.ai-config/shared/coding/avoid-nesting.md`) is **not** in `inst/WORDLIST` yet
spellcheck stays green --- because the `Spellcheck` job checks out **without**
the `.ai-config` submodule, so fragment prose is never scanned. That is a
non-obvious gotcha worth recording so the next contributor doesn't assume a word
is "already accepted" just because it renders in the published manual.

## What

One note appended to the `Spellcheck` bullet under **CI checks and how to
satisfy them** in `CLAUDE.md`:

- The job checks out without the `.ai-config` submodule, so `.ai-config/shared/*.md`
  prose is not scanned.
- A new word added to a file in **this** repo must be dictionary-valid or listed
  in `inst/WORDLIST` --- don't rely on a transcluded fragment having "introduced"
  it.

Docs-only; no content or workflow change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lda7pKa7N6YH22pJB2cZjW)_