### PR TITLE
docs: add Pull Request Roles section to GitHub chapter

### DIFF
--- a/ai-tools/reviewing-copilot-prs.qmd
+++ b/ai-tools/reviewing-copilot-prs.qmd
@@ -3,14 +3,22 @@ follow these guidelines to avoid confusion and ensure smooth collaboration:
 
 **Understanding PR roles:**
 
-Different people may play different roles in the PR lifecycle:
+The general PR roles (issue creator, author, reviewer, merger, assignee, and PR steward)
+are described in @sec-pr-roles.
+Copilot-assisted workflows add two more:
 
-- **Issue creator**: Reports a bug, suggests a feature, or requests other improvements. In projects with external users, issue creators often cannot assign issues to developers and are therefore distinct from the PR prompter
-- **PR prompter**: Assigns a developer (human or AI) to start working on a PR, often by assigning an issue to Copilot. The PR prompter is sometimes the same person as the issue creator, but often is a project maintainer who reviews and triages external issue reports
-- **PR author(s)**: Makes commits to the PR branch (when Copilot creates commits, both Copilot and the prompter are co-authors)
-- **PR manager**: Supervises and guides the PR authors, assigns reviewers, and controls the PR workflow. Typically the PR prompter becomes the PR manager, but can hand off this role to someone else
-- **PR reviewer(s)**: Reviews the PR and provides feedback. The PR manager often also serves as the lead reviewer
-- **PR assignee(s)**: Listed in the "Assignees" field on GitHub to indicate who is responsible for the PR. Use this field to clarify current ownership and track who should be working on addressing feedback
+- **PR prompter**: Assigns a developer (human or AI) to start working on a PR,
+  often by assigning an issue to Copilot.
+  The PR prompter is sometimes the same person as the issue creator,
+  but is often a project maintainer who reviews and triages external issue reports.
+  When Copilot creates commits,
+  both Copilot and the prompter are listed as co-authors.
+  Typically the PR prompter becomes the PR manager.
+- **PR manager**: Supervises and guides the PR authors,
+  assigns reviewers,
+  and controls the PR workflow,
+  deciding when and how Copilot makes additional changes.
+  The PR manager can hand off this role to someone else.
 
 **The scenario:**
 

--- a/github.qmd
+++ b/github.qmd
@@ -117,6 +117,10 @@ A standard workflow when starting on a new project and contributing code looks l
 
 : Standard Git workflow for new projects {#tbl-git-workflow}
 
+## Pull Request Roles {#sec-pr-roles}
+
+{{< include github/_sec-pr-roles.qmd >}}
+
 Other helpful commands are listed below.
 
 ## Commonly Used Git Commands

--- a/github.qmd
+++ b/github.qmd
@@ -121,8 +121,6 @@ A standard workflow when starting on a new project and contributing code looks l
 
 {{< include github/_sec-pr-roles.qmd >}}
 
-Other helpful commands are listed below.
-
 ## Commonly Used Git Commands
 
 | Command   | Description      |

--- a/github/_sec-pr-roles.qmd
+++ b/github/_sec-pr-roles.qmd
@@ -2,7 +2,7 @@ Every pull request involves at least two people:
 an author and a reviewer.
 Larger teams often designate a merger and a PR steward as well.
 
-**Author**
+### Author {#sec-pr-author}
 
 The author opens the PR,
 writes a clear description,
@@ -10,19 +10,19 @@ and links it to the relevant issue with `Closes #N` in the PR body.
 The author implements review feedback
 and resolves merge conflicts before re-requesting review.
 
-**Reviewer**
+### Reviewer {#sec-pr-reviewer}
 
 The reviewer reads the diff,
 checks the code for correctness and style,
 and either approves or requests changes.
 
-**Merger**
+### Merger {#sec-pr-merger}
 
 The merger executes the final merge
 once the PR is approved and all CI checks pass.
 This is often the same person as the reviewer.
 
-**PR Steward**
+### PR Steward {#sec-pr-steward}
 
 A PR steward keeps the review queue healthy.
 The steward monitors open PRs,
@@ -30,5 +30,5 @@ assigns reviewers when none are assigned,
 follows up on stalled reviews,
 and helps resolve disagreements between authors and reviewers.
 This is typically a rotating duty for a senior contributor or release manager.
-The [p5.js steward guidelines](https://beta.p5js.org/contribute/steward_guidelines/)
-provide one example of how to structure the role.
+The p5.js project documents how it structures this role in its
+[contributor docs](https://github.com/processing/p5.js-website/blob/main/src/content/contributor-docs/en/steward_guidelines.mdx).

--- a/github/_sec-pr-roles.qmd
+++ b/github/_sec-pr-roles.qmd
@@ -1,0 +1,34 @@
+Every pull request involves at least two people:
+an author and a reviewer.
+Larger teams often designate a merger and a PR steward as well.
+
+**Author**
+
+The author opens the PR,
+writes a clear description,
+and links it to the relevant issue with `Closes #N` in the PR body.
+The author implements review feedback
+and resolves merge conflicts before re-requesting review.
+
+**Reviewer**
+
+The reviewer reads the diff,
+checks the code for correctness and style,
+and either approves or requests changes.
+
+**Merger**
+
+The merger executes the final merge
+once the PR is approved and all CI checks pass.
+This is often the same person as the reviewer.
+
+**PR Steward**
+
+A PR steward keeps the review queue healthy.
+The steward monitors open PRs,
+assigns reviewers when none are assigned,
+follows up on stalled reviews,
+and helps resolve disagreements between authors and reviewers.
+This is typically a rotating duty for a senior contributor or release manager.
+The [p5.js steward guidelines](https://beta.p5js.org/contribute/steward_guidelines/)
+provide one example of how to structure the role.

--- a/github/_sec-pr-roles.qmd
+++ b/github/_sec-pr-roles.qmd
@@ -1,6 +1,14 @@
-Every pull request involves at least two people:
-an author and a reviewer.
-Larger teams often designate a merger and a PR steward as well.
+Every pull request involves several people,
+each with a distinct role.
+
+### Issue Creator {#sec-pr-issue-creator}
+
+The issue creator reports a bug,
+suggests a feature,
+or requests other improvements.
+In projects with external contributors,
+the issue creator often cannot assign issues to developers
+and is typically distinct from the PR author.
 
 ### Author {#sec-pr-author}
 
@@ -21,6 +29,13 @@ and either approves or requests changes.
 The merger executes the final merge
 once the PR is approved and all CI checks pass.
 This is often the same person as the reviewer.
+
+### Assignee {#sec-pr-assignee}
+
+The assignee is listed in the "Assignees" field on GitHub
+to indicate who is currently responsible for the PR.
+This field clarifies ownership
+and tracks who should be addressing open feedback.
 
 ### PR Steward {#sec-pr-steward}
 


### PR DESCRIPTION
Adds a new "Pull Request Roles" section to `github.qmd`, explaining the four roles involved in a PR: Author, Reviewer, Merger, and PR Steward.

The PR Steward role --- responsible for keeping the review queue healthy, assigning reviewers, and unblocking stalled PRs --- was the main motivation for this issue. The other three roles are included for completeness since readers need context to understand what makes the steward role distinct.

Content lives in a new fragment `github/_sec-pr-roles.qmd`, following the chapter's include pattern.

Closes #346

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZhVnz8FVtCZeBs54pH7Z)_