### PR TITLE
ai-tools: add a section explaining what an "AI harness" is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,10 @@ includes directly. That is separate from `.ai-config/shared/`.
   via a transcluded fragment (e.g. "inspectable" in `avoid-nesting.md`).
   A new word you add to a file in this repo must be dictionary-valid
   or listed in `inst/WORDLIST`.
+  Before pushing, grep any new proper noun, product name, or acronym you
+  introduced against `inst/WORDLIST` yourself --- catching it up front avoids
+  a spellcheck-fail-then-fix round trip per term (all-caps acronyms are not
+  reliably auto-skipped).
 - Link check (`check-links.yml`, `lycheeverse/lychee-action`) over `.qmd`/`.md`/
   `.html`. Fix broken links; only add an exclusion to `lychee.toml` when a URL
   is valid for humans but trips the automated checker.
@@ -97,7 +101,11 @@ includes directly. That is separate from `.ai-config/shared/`.
   files must use ASCII only - no curly quotes, no en/em dashes. Use `"`, `'`,
   and `-` (or write the dash as `---` in prose, which Quarto renders as an em dash).
 - Render/deploy (`publish.yml`, `preview.yml`) and bibliography DOI checks
-  (`check-bibliography-dois.yml`).
+  (`check-bibliography-dois.yml`). The full-book render (HTML + PDF + DOCX +
+  EPUB) plus PR-preview deploy legitimately takes 10-15 minutes; its check-run
+  status can lag behind actual completion in the GitHub API, so confirm via
+  the job's own step list or the preview-deploy comment's timestamp before
+  concluding it is stuck.
 
 Don't bypass a failing check; fix the underlying issue.
 
@@ -113,6 +121,10 @@ Don't bypass a failing check; fix the underlying issue.
   [`{dplyr}`](https://dplyr.tidyverse.org/). No raw HTML in `.qmd`.
 - Use Quarto cross-references: `#fig-`, `#tbl-`, `#sec-`, etc., referenced with
   `@fig-label`. Store images locally under `assets/images/`, not external URLs.
+  A bare markdown anchor link like `[text](#sec-foo)` is **not** the same
+  thing and will pass a render but fail review --- always use `[text](@sec-foo)`
+  for an internal cross-reference, even when linking custom prose text rather
+  than the auto-generated "Section N".
 - Use `#| code-fold: true` when the output is the point and the code is incidental.
 - R style: tidyverse, native `|>` pipe, `snake_case`, `.qmd` not `.Rmd`.
 

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -52,7 +52,7 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/how-agents-are-implemented.qmd >}}
 
-### How Harnesses and Agents Are Built {#sec-ai-file-formats}
+### How Harnesses and Agents Are Built {#sec-ai-harness-construction}
 
 {{< include ai-tools/how-harnesses-and-agents-are-built.qmd >}}
 

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -60,6 +60,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/what-kind-of-program-is-an-agent.qmd >}}
 
+### How Does a Harness Relate to an Agent? {#sec-ai-harness-agent-relationship}
+
+{{< include ai-tools/harness-agent-relationship.qmd >}}
+
 ### AI Agents and the Technological Singularity
 
 {{< include ai-tools/technological-singularity.qmd >}}

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -40,6 +40,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/what-are-ai-coding-agents.qmd >}}
 
+### What are AI harnesses? {#sec-ai-harnesses}
+
+{{< include ai-tools/what-are-ai-harnesses.qmd >}}
+
 ### AI Agents and the Technological Singularity
 
 {{< include ai-tools/technological-singularity.qmd >}}

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -36,6 +36,10 @@ as best practices and capabilities continue to evolve.
 We recommend working with **[AI coding agents](https://github.com/features/copilot/agents)** 
 to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_development).
 
+### What Is a Language Model? {#sec-ai-language-model}
+
+{{< include ai-tools/what-is-a-language-model.qmd >}}
+
 ### What are AI coding agents?
 
 {{< include ai-tools/what-are-ai-coding-agents.qmd >}}
@@ -47,6 +51,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 ### How Agents Are Structured and Implemented {#sec-ai-agent-implementation}
 
 {{< include ai-tools/how-agents-are-implemented.qmd >}}
+
+### How Harnesses and Agents Are Built {#sec-ai-file-formats}
+
+{{< include ai-tools/how-harnesses-and-agents-are-built.qmd >}}
 
 ### AI Agents and the Technological Singularity
 

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -56,6 +56,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/how-harnesses-and-agents-are-built.qmd >}}
 
+### What Kind of Program Is an Agent? {#sec-ai-agent-program-kind}
+
+{{< include ai-tools/what-kind-of-program-is-an-agent.qmd >}}
+
 ### AI Agents and the Technological Singularity
 
 {{< include ai-tools/technological-singularity.qmd >}}

--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -44,6 +44,10 @@ to [help you code](https://en.wikipedia.org/wiki/AI-assisted_software_developmen
 
 {{< include ai-tools/what-are-ai-harnesses.qmd >}}
 
+### How Agents Are Structured and Implemented {#sec-ai-agent-implementation}
+
+{{< include ai-tools/how-agents-are-implemented.qmd >}}
+
 ### AI Agents and the Technological Singularity
 
 {{< include ai-tools/technological-singularity.qmd >}}

--- a/ai-tools/harness-agent-relationship.qmd
+++ b/ai-tools/harness-agent-relationship.qmd
@@ -1,0 +1,88 @@
+The relationship between a harness and an agent is closer to an
+**[interpreter](https://en.wikipedia.org/wiki/Interpreter_(computing))**
+running a program than to two peers calling each other.
+
+#### Does the Harness Call the Agent, or the Agent Call the Harness?
+
+**Harness to agent: not a call, an instantiation.**
+The harness does not "call" an agent as a subroutine it invokes and waits on.
+An agent has no code of its own outside the harness's loop
+(see @sec-ai-agent-program-kind) ---
+its whole behavior *is* that loop,
+running with the agent's configuration
+(instructions, tool allowlist, model)
+loaded in.
+The harness instantiates and runs an agent, start to termination;
+it is not a function call with a return address.
+
+**Agent to harness: yes, a real call, via tool calls.**
+While an agent's loop is running,
+the model produces a
+[tool-call request](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview),
+and the harness's dispatcher looks up and executes the matching handler ---
+read a file,
+run a command,
+call an API.
+So the concrete direction of calling is
+**agent calls harness**,
+through tool dispatch,
+not the reverse.
+
+**Agent to agent: routed through the harness.**
+When a parent agent spawns a subagent,
+it does not call that subagent directly.
+It issues a tool call that the harness's dispatcher handles by spinning up
+a fresh instance of its own loop
+(see @sec-ai-agent-implementation),
+running it to completion with the subagent's configuration,
+and handing the result back to the parent as a tool result.
+Even "agent calls agent" bottoms out as:
+parent calls harness,
+harness instantiates and runs a new agent,
+harness returns that agent's output to the parent.
+
+#### What Do You Launch When You Type `claude`?
+
+Typing `claude` at a shell starts the harness process:
+it initializes the engine ---
+the permission system,
+the tool registry,
+MCP client connections,
+and memory loaded from `CLAUDE.md`/`AGENTS.md` files.
+But the harness does not sit idle waiting for a program to be supplied
+separately.
+It immediately instantiates the **default agent** ---
+the "main session" ---
+to handle the interactive conversation:
+full tool access,
+a system prompt assembled from the loaded config,
+no restricted allowlist.
+That default agent is simply the harness's baseline configuration for its
+own loop,
+not a second thing launched afterward.
+
+There is no observable moment of
+"harness running, no agent yet."
+The closest analogy is typing `python` at a shell:
+it launches the interpreter *and* drops you straight into a
+[REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
+evaluating your input,
+rather than leaving the interpreter idle with nothing loaded.
+The difference is that the harness's default "program" is built in
+(the main-session agent's configuration),
+rather than something you must supply.
+A custom subagent or a
+`.claude/agents/*.md` definition,
+by contrast,
+*is* a separate agent,
+instantiated on demand,
+mid-session,
+when the already-running main agent issues a tool call for it.
+
+So typing `claude` launches the harness,
+and that act inherently instantiates the default agent that handles the
+session:
+**harness** names the engine and process;
+**agent** names the particular loop instance and configuration currently
+running inside it.
+At startup, those two come into existence together.

--- a/ai-tools/harness-agent-relationship.qmd
+++ b/ai-tools/harness-agent-relationship.qmd
@@ -41,6 +41,57 @@ parent calls harness,
 harness instantiates and runs a new agent,
 harness returns that agent's output to the parent.
 
+#### Sketching the Harness's Own Loop
+
+The [agent loop](@sec-ai-agent-program-kind) sketched earlier is really just
+the innermost piece.
+The harness wraps a bootstrap step and a permission/dispatch layer around it:
+
+```python
+def run_harness():
+    # Load everything the loop will need before any conversation starts.
+    tools = load_tool_registry()          # built-ins, plus whatever MCP servers expose
+    memory = load_memory(CLAUDE_MD_PATHS) # CLAUDE.md / AGENTS.md, concatenated
+
+    # The "main session" is just the harness's own loop, run with a default,
+    # unrestricted configuration -- not a separate program.
+    main_agent = Agent(config=default_config, system_prompt=memory)
+    return run_agent(main_agent, tools)
+
+def run_agent(agent, tools):
+    history = [agent.system_prompt, agent.first_message]
+    while True:
+        response = call_model(history, tools=agent.tool_schemas)
+        history.append(response)
+        if not response.tool_calls:
+            break
+        for call in response.tool_calls:
+            # Every tool call passes through the harness's own gate first,
+            # regardless of which agent requested it.
+            check_permission(call)
+
+            if call.name == "spawn_subagent":
+                # A subagent is not called directly -- the harness recurses
+                # into a fresh instance of this same loop, then hands the
+                # finished result back as an ordinary tool result.
+                result = run_agent(Agent(call.arguments), tools)
+            else:
+                result = tools[call.name](call.arguments)
+
+            history.append(result)
+    return history[-1]
+```
+
+`run_agent` is identical in shape to the loop in @sec-ai-agent-program-kind.
+`run_harness` and the permission check are the parts that only exist at the
+harness level,
+not inside any individual agent.
+That recursive call ---
+`run_agent` calling itself for a subagent ---
+is the concrete mechanism behind
+"agent calls agent, routed through the harness,"
+described in the previous subsection.
+
 #### What Do You Launch When You Type `claude`?
 
 Typing `claude` at a shell starts the harness process:

--- a/ai-tools/how-agents-are-implemented.qmd
+++ b/ai-tools/how-agents-are-implemented.qmd
@@ -1,0 +1,76 @@
+An **agent** is not part of the harness itself.
+It is a configuration --- a goal, a role, a bounded toolset,
+and a stopping condition --- executed on top of the harness's core loop
+(see @sec-ai-harnesses).
+A single harness can host many different agents at once:
+a main conversation, and any number of subagents it spawns.
+
+#### The Shape of an Agent
+
+Structurally,
+an agent is a small record plus a fresh execution of the harness's loop:
+
+- **Identity**: a name and description,
+  used to route a task to the right agent
+  ("when should this agent be picked?").
+- **Instructions**: a system-prompt fragment that specializes behavior,
+  for example "you are a read-only search agent."
+- **Tool allowlist**: a subset of the harness's tool registry
+  this agent may call --- often narrower than the caller's own toolset.
+- **Model and effort**: which model backs the agent,
+  and how much reasoning depth it applies;
+  these can differ from the caller's own settings.
+- **Output contract**: whether the agent returns free text,
+  or must call a schema-validated tool to return a typed result.
+
+#### How an Agent Runs
+
+1. **Spawn**: allocate a fresh message history with no inherited conversation
+   --- just the agent's instructions,
+   plus whatever prompt the caller wrote.
+   A subagent prompt needs to be self-contained for this reason:
+   brief it like a colleague who just walked into the room.
+2. **Run**: execute the harness's core loop
+   (model call, parse tool calls, execute against the allowlist,
+   append results, repeat),
+   the same machinery the main session uses,
+   just bound to a narrower toolset and a different system prompt.
+3. **Terminate**: stop when the model emits a final answer with no further
+   tool calls,
+   when a schema-validated call satisfies the output contract,
+   when it hits an error or a budget ceiling,
+   or when the caller kills it.
+4. **Return**: everything that happened inside the agent
+   --- every tool call, every intermediate step ---
+   is discarded from the caller's context.
+   Only the final text or validated object crosses back.
+   This is the point of an agent:
+   it is a context-isolation boundary, not just a prompt.
+
+#### Composability and Its Limits
+
+Agents can spawn agents:
+an orchestration layer runs many agent instances,
+some concurrently,
+and composes their results.
+Nesting is deliberately capped,
+usually to one level,
+because unbounded recursion has no natural stopping point
+and burns cost and time with no guardrail.
+An orchestration script is a scheduler over independent agent-loop instances,
+not a different execution model.
+
+#### Two Axes That Define an Agent's Behavior
+
+- **Isolation versus continuation**: a subagent gets no inherited context
+  (isolation);
+  a resumed agent keeps its own accumulated history and continues it
+  (continuation).
+  Both use the same loop machinery,
+  differing only in history-management policy.
+- **Free-form versus structured output**: by default an agent returns prose.
+  Given a schema,
+  it is forced to call a structured-output tool instead,
+  turning it into a typed function from the caller's point of view
+  --- input in, validated object out ---
+  even though internally it is still a multi-turn loop.

--- a/ai-tools/how-harnesses-and-agents-are-built.qmd
+++ b/ai-tools/how-harnesses-and-agents-are-built.qmd
@@ -41,7 +41,7 @@ The front matter is parsed as structured configuration
 (name, description, allowed tools, model);
 the markdown body below it becomes that agent's system prompt,
 verbatim.
-An [Agent Skill's](#sec-ai-agent-skills) `SKILL.md` follows the same shape:
+An [Agent Skill's](@sec-ai-agent-skills) `SKILL.md` follows the same shape:
 front matter for discovery metadata,
 a markdown body for instructions,
 and an optional folder of bundled scripts or reference files alongside it.

--- a/ai-tools/how-harnesses-and-agents-are-built.qmd
+++ b/ai-tools/how-harnesses-and-agents-are-built.qmd
@@ -1,0 +1,80 @@
+The layers described above are not all built the same way.
+Some are ordinary software;
+others are just text files the harness reads at runtime.
+
+#### The Execution Engine Is Ordinary Software
+
+The program that runs the core loop ---
+calling the model,
+parsing tool calls,
+enforcing permissions,
+managing the sandbox ---
+is compiled or interpreted source code,
+the same as any other application.
+There is no markdown involved here;
+this layer is what makes a harness a harness,
+rather than just a prompt someone wrote.
+
+#### Agent and Skill Definitions Are Markdown with a Front Matter Header
+
+An agent's identity,
+and a skill's metadata,
+are usually just a markdown file with a
+[YAML front matter](https://jekyllrb.com/docs/front-matter/) header.
+For example,
+a custom [Claude Code subagent](https://docs.claude.com/en/docs/claude-code/sub-agents)
+defined in `.claude/agents/code-reviewer.md`:
+
+```markdown
+---
+name: code-reviewer
+description: Reviews diffs for bugs and style issues.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a meticulous code reviewer. Focus on correctness,
+security, and idiomatic style.
+```
+
+The front matter is parsed as structured configuration
+(name, description, allowed tools, model);
+the markdown body below it becomes that agent's system prompt,
+verbatim.
+An [Agent Skill's](#sec-ai-agent-skills) `SKILL.md` follows the same shape:
+front matter for discovery metadata,
+a markdown body for instructions,
+and an optional folder of bundled scripts or reference files alongside it.
+No compilation step is involved;
+the harness reads the file and uses it directly.
+
+#### Tools Are a Schema Paired with a Handler
+
+A tool definition has two parts:
+a [JSON Schema](https://json-schema.org/) describing its parameters,
+which is the only part the model ever sees,
+and a handler function,
+ordinary code that performs the actual action
+(reading a file, running a command, calling an API).
+The schema is declarative data;
+the handler is real software the model never inspects or writes.
+
+#### Orchestration Needs Real Code
+
+Multi-agent orchestration cannot be expressed declaratively,
+because it needs genuine control flow ---
+loops,
+conditionals,
+parallel fan-out with a concurrency limit.
+So orchestration scripts are literal source files,
+executed by the harness,
+not parsed as prompt text the way an agent definition is.
+
+#### Memory Is Just Prose
+
+Files like this manual,
+or a repository's `CLAUDE.md`/[`AGENTS.md`](https://agents.md/),
+carry no front matter and no schema.
+They are concatenated into the system prompt as plain text,
+and the harness trusts the model to read and follow that prose,
+the same way it follows any other instruction in its context.

--- a/ai-tools/what-are-ai-harnesses.qmd
+++ b/ai-tools/what-are-ai-harnesses.qmd
@@ -9,10 +9,11 @@ and carry state across turns and sessions.
 #### Layers of a Harness
 
 Most coding-agent harnesses ---
-including the GitHub Copilot coding agent and Claude Code ---
+including the [GitHub Copilot coding agent](https://github.com/features/copilot/agents)
+and [Claude Code](https://claude.com/product/claude-code) ---
 share a similar set of layers:
 
-- **Core loop**: the tool-calling loop,
+- **Core loop**: the [tool-calling loop](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview),
   permission and sandboxing model,
   and context management that keep the agent grounded in your repository.
 - **Skills**: reusable,
@@ -32,7 +33,7 @@ share a similar set of layers:
   beyond raw shell or API calls.
 - **Memory**: files ---
   like this manual,
-  or a repository's `CLAUDE.md`/`AGENTS.md` ---
+  or a repository's `CLAUDE.md`/[`AGENTS.md`](https://agents.md/) ---
   that persist instructions and learned preferences across sessions,
   so the harness does not relearn your conventions every time.
 
@@ -64,4 +65,5 @@ share a similar set of layers:
   PR comments,
   fetched web pages,
   and other tool output can contain text that looks like a command;
-  a harness that acts on it uncritically is vulnerable to prompt injection.
+  a harness that acts on it uncritically is vulnerable to
+  [prompt injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/).

--- a/ai-tools/what-are-ai-harnesses.qmd
+++ b/ai-tools/what-are-ai-harnesses.qmd
@@ -1,0 +1,67 @@
+An **AI harness** is the scaffolding built around a language model
+that turns it into an agent able to do real work.
+The model itself only predicts text;
+the harness is what lets it read files,
+run commands,
+call external tools and APIs,
+and carry state across turns and sessions.
+
+#### Layers of a Harness
+
+Most coding-agent harnesses ---
+including the GitHub Copilot coding agent and Claude Code ---
+share a similar set of layers:
+
+- **Core loop**: the tool-calling loop,
+  permission and sandboxing model,
+  and context management that keep the agent grounded in your repository.
+- **Skills**: reusable,
+  named procedures that encode a workflow so it runs the same way every time,
+  instead of being re-improvised in each conversation.
+  See [Agent Skills](#sec-ai-agent-skills).
+- **Subagents**: a way to spin up a worker with a fresh context window
+  for a self-contained piece of research or work,
+  keeping the main conversation's context focused.
+- **Multi-agent orchestration**: deterministic fan-out and fan-in across many subagents ---
+  for example,
+  running several independent reviewers over a diff and reconciling their findings ---
+  for work that is large or benefits from independent verification.
+- **MCP servers**: the [Model Context Protocol](https://modelcontextprotocol.io/)
+  gives a harness typed access to external systems
+  (issue trackers, chat tools, databases)
+  beyond raw shell or API calls.
+- **Memory**: files ---
+  like this manual,
+  or a repository's `CLAUDE.md`/`AGENTS.md` ---
+  that persist instructions and learned preferences across sessions,
+  so the harness does not relearn your conventions every time.
+
+#### Using Harness Features Well
+
+- **Push repeatable procedures into skills**,
+  not into ad hoc prompting each time.
+  A skill is testable,
+  shareable,
+  and versionable;
+  a one-off prompt is not.
+- **Match orchestration weight to the task.**
+  A single lookup or small edit should stay inline.
+  Reach for subagents or multi-agent workflows only when the work
+  is genuinely decomposable,
+  benefits from independent verification,
+  and is large enough that the coordination overhead pays for itself.
+- **Gate destructive or hard-to-reverse actions on explicit human approval** ---
+  merges,
+  force-pushes,
+  deletions ---
+  and let the agent drive everything reversible
+  (drafting, testing, iterating on review feedback) autonomously.
+- **Feed learnings back into the harness.**
+  When a review round or a mistake teaches something generalizable,
+  record it as a memory or skill update
+  rather than letting it evaporate at the end of the session.
+- **Treat external or untrusted content as data, not instructions.**
+  PR comments,
+  fetched web pages,
+  and other tool output can contain text that looks like a command;
+  a harness that acts on it uncritically is vulnerable to prompt injection.

--- a/ai-tools/what-are-ai-harnesses.qmd
+++ b/ai-tools/what-are-ai-harnesses.qmd
@@ -18,7 +18,7 @@ share a similar set of layers:
 - **Skills**: reusable,
   named procedures that encode a workflow so it runs the same way every time,
   instead of being re-improvised in each conversation.
-  See [Agent Skills](#sec-ai-agent-skills).
+  See @sec-ai-agent-skills.
 - **Subagents**: a way to spin up a worker with a fresh context window
   for a self-contained piece of research or work,
   keeping the main conversation's context focused.

--- a/ai-tools/what-is-a-language-model.qmd
+++ b/ai-tools/what-is-a-language-model.qmd
@@ -1,0 +1,33 @@
+A **[large language model](https://en.wikipedia.org/wiki/Large_language_model)**
+(LLM) is a statistical model trained to predict the next token
+in a sequence of text,
+based on patterns learned from enormous amounts of text during training.
+That single capability --- predicting what comes next ---
+turns out to be enough to write code,
+answer questions,
+and hold a conversation,
+once the model is large enough and trained on enough data.
+
+A base model trained only to predict text is not yet a helpful assistant.
+A further training step,
+often
+[reinforcement learning from human feedback](https://en.wikipedia.org/wiki/Reinforcement_learning_from_human_feedback),
+teaches the model to follow instructions,
+answer as a helpful assistant,
+and refuse harmful requests,
+rather than simply continuing whatever text it is given.
+This is the step that turns a raw language model into something
+like Claude or ChatGPT.
+
+A model call is stateless:
+given the same input,
+it has no memory of any previous call.
+Every capability the rest of this chapter describes ---
+holding a conversation,
+using tools,
+running autonomously as an agent ---
+is scaffolding built on top of that one stateless function.
+The harness supplies the memory,
+the tools,
+and the control flow;
+the model only ever predicts what token comes next.

--- a/ai-tools/what-kind-of-program-is-an-agent.qmd
+++ b/ai-tools/what-kind-of-program-is-an-agent.qmd
@@ -20,12 +20,20 @@ the same category as a network client.
 Its core loop can be sketched in a few lines:
 
 ```python
+# Start the conversation with the agent's instructions and the task.
 history = [system_prompt, user_message]
+
 while True:
+    # Send everything so far to the model, along with what it's allowed to call.
     response = call_model(history, tools=tool_schemas)
     history.append(response)
+
+    # No tool calls means the model gave a final answer -- stop.
     if not response.tool_calls:
         break
+
+    # Otherwise, run each requested tool and feed the result back in,
+    # so the next model call can see what happened.
     for call in response.tool_calls:
         result = tool_registry[call.name](call.arguments)
         history.append(result)

--- a/ai-tools/what-kind-of-program-is-an-agent.qmd
+++ b/ai-tools/what-kind-of-program-is-an-agent.qmd
@@ -1,0 +1,82 @@
+An agent is not a standalone program that does the reasoning itself.
+It is an
+**[orchestration](https://en.wikipedia.org/wiki/Orchestration_(computing))**
+program:
+something closer in shape to a chat client or a build tool than to a
+compiler or a web server.
+
+#### It Is I/O-Bound, Not Compute-Bound
+
+The actual token prediction happens on remote inference infrastructure,
+reached over HTTPS.
+The agent process itself does no heavy computation;
+it spends almost all its wall-clock time waiting ---
+for a model API response,
+for a shell command to finish,
+for a file read.
+Structurally it is an
+**[event-loop](https://en.wikipedia.org/wiki/Event_loop)** program,
+the same category as a network client.
+Its core loop can be sketched in a few lines:
+
+```python
+history = [system_prompt, user_message]
+while True:
+    response = call_model(history, tools=tool_schemas)
+    history.append(response)
+    if not response.tool_calls:
+        break
+    for call in response.tool_calls:
+        result = tool_registry[call.name](call.arguments)
+        history.append(result)
+```
+
+Everything a harness adds --- permissions, sandboxing, memory, subagents ---
+is scaffolding wrapped around this loop,
+not a replacement for it.
+
+#### Real Open-Source Examples
+
+Because most production coding-agent harnesses are closed source, the
+clearest way to see this shape in real code is to read an open-source one:
+
+- **[aider](https://github.com/Aider-AI/aider)** --- an open-source AI
+  pair-programming CLI.
+- **[SWE-agent](https://github.com/SWE-agent/SWE-agent)** --- a research
+  coding-agent harness from Princeton NLP,
+  described in its associated paper.
+- **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** (formerly
+  OpenDevin) --- a general-purpose open-source agent platform.
+
+Their orchestration code runs to thousands of lines,
+because that is where the real engineering lives:
+retries,
+streaming,
+permission checks,
+and state management.
+A single *agent definition* running on top of that engine,
+by contrast,
+is typically tens of lines
+(see @sec-ai-harness-construction).
+
+#### Where It Runs
+
+- **The harness process**: an ordinary OS process,
+  either on your own machine (CLI mode) or inside an ephemeral,
+  managed cloud container (remote/web mode) that is discarded when the
+  session ends.
+- **Subagents**: run inside the *same* host process as their caller,
+  not a separate container.
+  They differ only in having their own message history and a narrower
+  tool set,
+  unless a workflow explicitly asks for a separate git
+  [worktree](https://git-scm.com/docs/git-worktree) to avoid file
+  conflicts during parallel edits.
+- **The model call itself**: not part of the agent's environment at all.
+  It is a network request to inference infrastructure the agent has no
+  visibility into,
+  beyond the request and response.
+
+So an agent's lifetime is scoped to a single task, not persistent: it
+starts when given a goal, runs for as long as its loop keeps producing
+tool calls, and ends the moment a stopping condition fires.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,11 +2,13 @@ Aiemjoy
 Barratt
 Burkholderia
 CE
+ChatGPT
 Djajadi
 Drs
 Fanice
 GitLab
 Heitmann
+Jekyll
 Kunal
 LeCun
 Melioidosis

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -15,6 +15,8 @@ Melioidosis
 Mishra
 NonCommercial
 Nyatigo
+OpenDevin
+OpenHands
 Orientia
 Paratyphi
 Pokpongkiat
@@ -28,6 +30,7 @@ UC
 UCD
 UCSF
 Vibrio
+aider
 cholerae
 edu
 gh

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -38,6 +38,8 @@ pseudomallei
 reattach
 seroepidemiologic
 spp
+subagent
+subagents
 tsutsugamushi
 ucdavis
 ucdserg

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -20,6 +20,7 @@ OpenHands
 Orientia
 Paratyphi
 Pokpongkiat
+REPL
 Rails
 SERG
 SWE

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -22,6 +22,7 @@ Paratyphi
 Pokpongkiat
 Rails
 SERG
+SWE
 SeRG
 Seroepidemiology
 Shigella


### PR DESCRIPTION
## Summary

- Adds a new fragment `ai-tools/what-are-ai-harnesses.qmd` explaining what an
  AI harness is (the scaffolding around a language model --- tool-calling
  loop, permissions, context management) and its common layers (skills,
  subagents, multi-agent orchestration, MCP servers, memory), plus guidance
  on matching orchestration weight to the task, gating destructive actions
  on human approval, and feeding learnings back into the harness.
- Wires the new section into `ai-tools.qmd` as "What are AI harnesses?"
  (`#sec-ai-harnesses`), right after "What are AI coding agents?".
- Adds `subagent`/`subagents` to `inst/WORDLIST` for the spellcheck job.

Closes #369.

## Test plan

- [ ] `quarto render ai-tools.qmd --to html` renders without error
- [ ] Spellcheck CI passes
- [ ] Link check CI passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01NfPFq3tyWS6TLykTcpnFnS)_