### PR TITLE
fix: pin Rcpp to 1.1.1-1.1 to fix R 4.6 CI build failure

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -54,10 +54,10 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.1.1",
+      "Version": "1.1.1-1.1",
       "Source": "Repository",
       "Title": "Seamless R and C++ Integration",
-      "Date": "2026-01-07",
+      "Date": "2026-04-19",
       "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(\"Romain\", \"Francois\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"JJ\", \"Allaire\", role = \"aut\", comment = c(ORCID = \"0000-0003-0174-9868\")), person(\"Kevin\", \"Ushey\", role = \"aut\", comment = c(ORCID = \"0000-0003-2880-7407\")), person(\"Qiang\", \"Kou\", role = \"aut\", comment = c(ORCID = \"0000-0001-6786-5453\")), person(\"Nathan\", \"Russell\", role = \"aut\"), person(\"Iñaki\", \"Ucar\", role = \"aut\", comment = c(ORCID = \"0000-0001-6403-5550\")), person(\"Doug\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"John\", \"Chambers\", role = \"aut\"))",
       "Description": "The 'Rcpp' package provides R functions as well as C++ classes which offer a seamless integration of R and C++. Many R data types and objects can be mapped back and forth to C++ equivalents which facilitates both writing of new code as well as easier integration of third-party libraries. Documentation about 'Rcpp' is provided by several vignettes included in this package, via the 'Rcpp Gallery' site at <https://gallery.rcpp.org>, the paper by Eddelbuettel and Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013, <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018, <doi:10.1080/00031305.2017.1375990>); see 'citation(\"Rcpp\")' for details.",
       "Depends": [


### PR DESCRIPTION
## Summary

- `renv.lock` pinned `Rcpp` at 1.1.1, which fails to compile against R 4.6.1 because `R_NamespaceRegistry` was dropped from R's public C API in 4.6.0
- Bumps the lockfile record to Rcpp 1.1.1-1.1 (CRAN, 2026-04-24), which fixes this upstream (RcppCore/Rcpp#1473, landed via RcppCore/Rcpp#1469)

Closes #371

## Test plan

- [x] Ran `renv::install("Rcpp@1.1.1-1.1")` and built it from source against local R 4.6.0 with a cleared cache (`renv::repair()` confirmed the project library links correctly)
- [x] Confirmed no `R_NamespaceRegistry` compile error
- [x] Loaded `Rcpp` and ran `cppFunction()` to compile and execute a trivial C++ function successfully
- [ ] CI (`lint-project`, `build-deploy`) should now pass `renv::restore()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)