### PR TITLE
docs: note lms's new function-length/complexity linters and lintr exclusion gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,15 @@ includes directly. That is separate from `.ai-config/shared/`.
 - Lint (`lint-project.yaml`, `lintr::lint_dir()`). The root `.lintr.R` calls
   `lms::default_linters()`, so install the local `lms` package first:
   `R CMD INSTALL lms`. Repo-specific exclusions stay in `.lintr.R`, not in `lms`.
+  `default_linters()` includes `cyclocomp_linter()` and a custom
+  `function_length_linter()` (the `<150` line heuristic from
+  `coding-practices/function-length-limits.qmd`; lintr has no built-in
+  line-count linter). If `lms` grows a `tests/` directory, the standard
+  testthat boilerplate's `library()` calls need their own `.lintr.R`
+  exclusion entry keyed to the nested path (e.g. `"lms/tests/testthat.R"`)
+  --- the existing root-level `"tests/testthat.R"` exclusion entry is for a
+  different, not-yet-existing root-level tests directory and does not match
+  nested paths.
 - Non-standard characters (`check-non-standard-chars.yaml`). `.qmd` and `.R`
   files must use ASCII only - no curly quotes, no en/em dashes. Use `"`, `'`,
   and `-` (or write the dash as `---` in prose, which Quarto renders as an em dash).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,10 +100,11 @@ includes directly. That is separate from `.ai-config/shared/`.
   `default_linters()` includes `cyclocomp_linter()` and a custom
   `function_length_linter()` (the `<150` line heuristic from
   `coding-practices/function-length-limits.qmd`; lintr has no built-in
-  line-count linter). If `lms` grows a `tests/` directory, the standard
-  testthat boilerplate's `library()` calls need their own `.lintr.R`
-  exclusion entry keyed to the nested path (e.g. `"lms/tests/testthat.R"`)
-  --- the existing root-level `"tests/testthat.R"` exclusion entry is for a
+  line-count linter). `lms/tests/testthat.R` already has its own `.lintr.R`
+  exclusion entry; the same pattern applies to any nested path --- the
+  standard testthat boilerplate's `library()` calls need an explicit entry
+  keyed to the nested path (e.g. `"lms/tests/testthat.R"`), since the
+  existing root-level `"tests/testthat.R"` exclusion entry is for a
   different, not-yet-existing root-level tests directory and does not match
   nested paths.
 - Non-standard characters (`check-non-standard-chars.yaml`). `.qmd` and `.R`


### PR DESCRIPTION
Follow-up to #381. Adds a short note to `CLAUDE.md`'s CI-checks section:

- `lms::default_linters()` now includes `cyclocomp_linter()` and the custom `function_length_linter()`.
- Nested `.lintr.R` exclusion paths (e.g. `lms/tests/testthat.R`) need their own exclusion entry — the existing root-level `"tests/testthat.R"` entry doesn't match nested paths, which cost a round trip while adding `lms/tests/` in #381.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137wwBueoxooRQWc7mBQsiw)_