### PR TITLE
check-dois: retry with backoff and treat transient resolver failures as warnings

### DIFF
--- a/.github/scripts/check-bibliography-dois.R
+++ b/.github/scripts/check-bibliography-dois.R
@@ -39,7 +39,7 @@ parse_bibtex_file <- function(filepath) {
 #' Check if entry has a DOI field
 #'
 #' @param entry Single bibliography entry (row from data frame)
-#' @return List with has_doi (logical) and error_message (string or NULL)
+#' @return List with has_doi (logical) and error (string or NULL)
 check_doi_field <- function(entry) {
   entry_type <- tolower(entry$CATEGORY)
   entry_key <- entry$BIBTEXKEY
@@ -62,7 +62,7 @@ check_doi_field <- function(entry) {
 #' resolver hiccup (timeout, 5xx) does not fail the whole check (#358).
 #'
 #' @param doi DOI string
-#' @return List with is_valid, error_message, status_code, and transient
+#' @return List with is_valid, error, status_code, and transient
 #'   (TRUE when the failure looks like resolver unavailability rather than
 #'   a genuinely broken DOI)
 validate_doi_url <- function(doi) {
@@ -287,13 +287,18 @@ compare_metadata <- function(entry, metadata) {
 #'
 #' @param filepath Path to bibliography file
 #' @param verify_metadata Whether to verify metadata (default TRUE)
-#' @return List with checked_count, errors_count, and error_messages
+#' @return List with checked_count, errors_count, errors, and warnings
 check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
   cat(sprintf("\nChecking %s...\n", filepath))
   
   bib_df <- parse_bibtex_file(filepath)
   if (is.null(bib_df)) {
-    return(list(checked_count = 0, errors_count = 1, errors = c("Failed to parse BibTeX file")))
+    return(list(
+      checked_count = 0,
+      errors_count = 1,
+      errors = c("Failed to parse BibTeX file"),
+      warnings = c()
+    ))
   }
   
   errors <- c()

--- a/.github/scripts/check-bibliography-dois.R
+++ b/.github/scripts/check-bibliography-dois.R
@@ -58,53 +58,76 @@ check_doi_field <- function(entry) {
 
 #' Validate that a DOI resolves to a valid URL
 #'
+#' Requests are retried with exponential backoff so that a transient
+#' resolver hiccup (timeout, 5xx) does not fail the whole check (#358).
+#'
 #' @param doi DOI string
-#' @return List with is_valid, error_message, and status_code
+#' @return List with is_valid, error_message, status_code, and transient
+#'   (TRUE when the failure looks like resolver unavailability rather than
+#'   a genuinely broken DOI)
 validate_doi_url <- function(doi) {
   # Clean up DOI
   doi <- trimws(doi)
-  
+
   # Extract just the DOI identifier
   doi_match <- str_extract(doi, "10\\.\\d+/[^\\s]+")
-  
+
   if (is.na(doi_match)) {
     return(list(
       is_valid = FALSE,
       error = sprintf("Invalid DOI format: %s", doi),
-      status_code = NULL
+      status_code = NULL,
+      transient = FALSE
     ))
   }
-  
+
   doi_identifier <- doi_match
   doi_url <- sprintf("https://doi.org/%s", doi_identifier)
-  
+
   tryCatch({
-    response <- GET(
+    # RETRY with exponential backoff; a 404/410 is definitive (the DOI
+    # itself is wrong), so it terminates the retries immediately.
+    response <- RETRY(
+      "GET",
       doi_url,
-      timeout(10),
-      user_agent("Mozilla/5.0 (compatible; BibliographyChecker/1.0)")
+      timeout(30),
+      user_agent("Mozilla/5.0 (compatible; BibliographyChecker/1.0)"),
+      times = 3,
+      pause_base = 2,
+      pause_cap = 16,
+      terminate_on = c(404, 410),
+      quiet = TRUE
     )
-    
+
     status_code <- status_code(response)
-    
+
     if (status_code == 200) {
       return(list(
         is_valid = TRUE,
         error = NULL,
-        status_code = status_code
+        status_code = status_code,
+        transient = FALSE
       ))
     } else {
       return(list(
         is_valid = FALSE,
         error = sprintf("DOI URL returned status %d", status_code),
-        status_code = status_code
+        status_code = status_code,
+        # 404/410 mean the DOI is genuinely broken; any other non-200
+        # that survived the retries (5xx, 429, other 4xx from an
+        # overloaded or bot-blocking resolver) is treated as transient.
+        transient = !(status_code %in% c(404, 410))
       ))
     }
   }, error = function(e) {
+    # A request that still errors after retries (timeout, connection
+    # failure) means the resolver was unavailable, not that the DOI is
+    # wrong.
     return(list(
       is_valid = FALSE,
       error = sprintf("Error accessing DOI: %s", e$message),
-      status_code = NULL
+      status_code = NULL,
+      transient = TRUE
     ))
   })
 }
@@ -125,12 +148,18 @@ get_doi_metadata <- function(doi) {
   api_url <- sprintf("https://api.crossref.org/works/%s", doi_identifier)
   
   tryCatch({
-    response <- GET(
+    response <- RETRY(
+      "GET",
       api_url,
-      timeout(10),
-      user_agent("Mozilla/5.0 (compatible; BibliographyChecker/1.0)")
+      timeout(30),
+      user_agent("Mozilla/5.0 (compatible; BibliographyChecker/1.0)"),
+      times = 3,
+      pause_base = 2,
+      pause_cap = 16,
+      terminate_on = c(404, 410),
+      quiet = TRUE
     )
-    
+
     if (status_code(response) == 200) {
       data <- fromJSON(content(response, as = "text", encoding = "UTF-8"))
       return(data$message)
@@ -268,6 +297,7 @@ check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
   }
   
   errors <- c()
+  resolver_warnings <- c()
   checked_count <- 0
   
   for (i in seq_len(nrow(bib_df))) {
@@ -303,6 +333,15 @@ check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
     
     # Check 2: DOI URL is valid
     url_check <- validate_doi_url(doi)
+    if (!url_check$is_valid && url_check$transient) {
+      warning_msg <- sprintf(
+        "Entry '%s': %s (resolver unavailable after retries; not treated as an error)",
+        entry$BIBTEXKEY, url_check$error
+      )
+      resolver_warnings <- c(resolver_warnings, warning_msg)
+      cat(sprintf("    ⚠️  %s\n", warning_msg))
+      next
+    }
     if (!url_check$is_valid) {
       error_msg <- sprintf("Entry '%s': %s", entry$BIBTEXKEY, url_check$error)
       errors <- c(errors, error_msg)
@@ -338,7 +377,8 @@ check_bibliography_file <- function(filepath, verify_metadata = TRUE) {
   return(list(
     checked_count = checked_count,
     errors_count = length(errors),
-    errors = errors
+    errors = errors,
+    warnings = resolver_warnings
   ))
 }
 
@@ -368,19 +408,21 @@ run_doi_validation <- function() {
   total_checked <- 0
   total_errors <- 0
   all_errors <- c()
-  
+  all_warnings <- c()
+
   for (filepath in files) {
     if (!file.exists(filepath)) {
       cat(sprintf("Error: File %s does not exist\n", filepath))
       quit(status = 1)
     }
-    
+
     result <- check_bibliography_file(filepath, verify_metadata = !no_metadata_check)
     total_checked <- total_checked + result$checked_count
     total_errors <- total_errors + result$errors_count
     all_errors <- c(all_errors, result$errors)
+    all_warnings <- c(all_warnings, result$warnings)
   }
-  
+
   # Print summary
   cat("\n")
   cat(paste(rep("=", 70), collapse = ""), "\n")
@@ -388,7 +430,15 @@ run_doi_validation <- function() {
   cat(paste(rep("=", 70), collapse = ""), "\n")
   cat(sprintf("Total entries checked: %d\n", total_checked))
   cat(sprintf("Errors found: %d\n", total_errors))
-  
+  cat(sprintf("Transient resolver warnings: %d\n", length(all_warnings)))
+
+  if (length(all_warnings) > 0) {
+    cat("\nWARNINGS (resolver unavailable; not failing the check):\n")
+    for (w in all_warnings) {
+      cat(sprintf("  • %s\n", w))
+    }
+  }
+
   if (total_errors > 0) {
     cat("\nERRORS:\n")
     for (error in all_errors) {


### PR DESCRIPTION
Closes #358

A single transient timeout or 5xx from an external DOI resolver was failing the whole `check-dois` job even when the bibliography entry is fine (observed on PR #357, where PLOS resolver flakiness failed three runs in a row on a docs-only change).

## Changes (`.github/scripts/check-bibliography-dois.R`)

- DOI resolution and CrossRef metadata requests now use `httr::RETRY()` (3 tries, exponential backoff with `pause_base = 2`, `pause_cap = 16`) instead of a single `GET()`.
- Per-request timeout raised from 10s to 30s.
- "Resolver was unavailable" is now distinguished from "this DOI is wrong": after retries, a timeout/connection error or a non-404/410 HTTP status is reported as a non-fatal warning (per entry in the log, and aggregated in the summary); only a definitive 404/410 or an invalid-DOI format fails the job.
- `terminate_on = c(404, 410)` stops retrying immediately on a definitive not-found, so broken DOIs don't waste the backoff cycle.

## Verification

- `parse()` passes on the edited script.
- RETRY semantics exercised against a local counting HTTP server: a 404 terminates after exactly 1 request, a 500 is retried 3 times with backoff (~6s), and a 200 passes through unchanged.
- The transient-error branch (connection failure) verified to return `transient = TRUE` (the sandbox proxy blocks doi.org, which conveniently exercised exactly that path).
- The happy path against real resolvers runs in this PR's own `check-dois` job.