### PR TITLE
docs: link the rendered p5.js steward guidelines instead of the raw .mdx source

### DIFF
--- a/github/_sec-pr-roles.qmd
+++ b/github/_sec-pr-roles.qmd
@@ -46,4 +46,4 @@ follows up on stalled reviews,
 and helps resolve disagreements between authors and reviewers.
 This is typically a rotating duty for a senior contributor or release manager.
 The p5.js project documents how it structures this role in its
-[contributor docs](https://github.com/processing/p5.js-website/blob/main/src/content/contributor-docs/en/steward_guidelines.mdx).
+[steward guidelines](https://p5js.org/contribute/steward_guidelines/).


### PR DESCRIPTION
Closes #361

Swaps the raw GitHub `.mdx` link in `github/_sec-pr-roles.qmd` for the rendered page, so readers land on formatted documentation instead of GitHub's file viewer showing MDX source. The link text changes from "contributor docs" to "steward guidelines" to match the destination page's own title.

## Verification

- Web search confirms `https://p5js.org/contribute/steward_guidelines/` is the live rendered page (the session's proxy blocks p5js.org directly, the same limitation noted in the issue).
- `lychee.toml`'s `accept` list already includes 403 (for sites that block automated checkers), so the link-checker passes whether or not p5js.org blocks lychee's requests; this PR's own link-checker run is the definitive check from an open-network runner.