### PR TITLE
Sync remaining ai-config shared/coding fragments into coding-style.qmd

### DIFF
--- a/coding-style.qmd
+++ b/coding-style.qmd
@@ -14,6 +14,18 @@ Follow these code style guidelines for all R code:
 
 {{< include .ai-config/shared/coding/avoid-nesting.md >}}
 
+## Prefer Existing Packaged Functions {#sec-prefer-packaged-functions}
+
+{{< include .ai-config/shared/coding/prefer-packaged-functions.md >}}
+
+## Prefer Per-Operation Grouping {#sec-per-operation-grouping}
+
+{{< include .ai-config/shared/coding/per-operation-grouping.md >}}
+
+## Avoid Hard-Coding Data with an External Source of Truth {#sec-avoid-hardcoding-external-data}
+
+{{< include .ai-config/shared/coding/avoid-hardcoding-external-data.md >}}
+
 ## Construct Complex Inputs Before the Call {#sec-construct-inputs}
 
 {{< include coding-style/construct-inputs.qmd >}}


### PR DESCRIPTION
Closes #377

Adds `{{< include >}}` sections in `coding-style.qmd` for the three ai-config `shared/coding` fragments that never got wired in after #328:

- `prefer-packaged-functions.md` → `## Prefer Existing Packaged Functions {#sec-prefer-packaged-functions}`
- `per-operation-grouping.md` → `## Prefer Per-Operation Grouping {#sec-per-operation-grouping}`
- `avoid-hardcoding-external-data.md` → `## Avoid Hard-Coding Data with an External Source of Truth {#sec-avoid-hardcoding-external-data}`

All three follow the existing `## heading + include` pattern used for `avoid-nesting.md`.

Also bumps the `.ai-config` submodule pin to ai-config `50e6649`, picking up d-morrison/ai-config#581 (removes a stray H1 from the per-operation-grouping fragment that would have rendered as an extra chapter-level heading here).

## Verification

- Rendered `coding-style.qmd`: all three new section ids present in the chapter HTML, and exactly one H1 (the chapter title) after the pin bump.
- No new prose in this repo's own files beyond the three headings, so no wordlist changes needed (the spellcheck job doesn't scan submodule fragments).