### PR TITLE
docs: recommend lint-changed-files over whole-project linting in CI

### DIFF
--- a/coding-style/_lint-changed-files-in-ci.qmd
+++ b/coding-style/_lint-changed-files-in-ci.qmd
@@ -17,7 +17,7 @@ In most cases,
 a better default is to lint **changed files only**,
 so pre-existing findings elsewhere in the project
 don't block unrelated work.
-[r-lib/actions](https://github.com/r-lib/actions/tree/v2-branch/examples)
+[r-lib/actions](https://github.com/r-lib/actions/blob/v2-branch/examples/lint-changed-files.yaml)
 provides a ready-made `lint-changed-files` example workflow;
 install it with `usethis::use_github_action("lint-changed-files")`.
 

--- a/coding-style/_lint-changed-files-in-ci.qmd
+++ b/coding-style/_lint-changed-files-in-ci.qmd
@@ -1,0 +1,28 @@
+A project can fall out of lint compliance
+without any change to its own source code or `.lintr` configuration:
+[`{lintr}`](https://lintr.r-lib.org/) releases sometimes add default linters
+or tighten existing ones,
+so code that passed yesterday can fail after a routine package update.
+
+When a continuous-integration job lints the whole project
+(for example, `lintr::lint_dir()` on every pull request),
+those newly introduced findings surface on whatever pull request
+happens to run CI next.
+That pull request then has to expand into unrelated files
+just to turn the lint check green,
+which conflicts with our expectation that a pull request
+stays scoped to one concern.
+
+In most cases,
+a better default is to lint **changed files only**,
+so pre-existing findings elsewhere in the project
+don't block unrelated work.
+[r-lib/actions](https://github.com/r-lib/actions/tree/v2-branch/examples)
+provides a ready-made `lint-changed-files` example workflow;
+install it with `usethis::use_github_action("lint-changed-files")`.
+
+Whole-project linting still has a place:
+run it on a schedule or as a manually triggered workflow,
+so that project-wide drift is still detected
+and cleaned up deliberately in its own dedicated pull request,
+rather than as a side effect of someone else's change.

--- a/coding-style/automated-tools.qmd
+++ b/coding-style/automated-tools.qmd
@@ -10,4 +10,8 @@
    
 #### [`{lintr}`](https://lintr.r-lib.org/)
 
-{{< include coding-style/_lintr-summary.qmd >}} 
+{{< include coding-style/_lintr-summary.qmd >}}
+
+### Linting Changed Files vs. the Whole Project in CI
+
+{{< include coding-style/_lint-changed-files-in-ci.qmd >}} 


### PR DESCRIPTION
Closes #283

A project can fall out of lint compliance without any change to its own code or `.lintr` config — `{lintr}` releases sometimes add or tighten default linters — and a whole-project lint job then blocks whatever unrelated PR runs CI next, forcing it to expand into unrelated files.

## Changes

- New `coding-style/_lint-changed-files-in-ci.qmd` fragment under a `### Linting Changed Files vs. the Whole Project in CI` heading in `coding-style/automated-tools.qmd`, right after the existing `{lintr}` block. It recommends changed-files-only linting as the CI default (r-lib/actions' `lint-changed-files` example workflow, installed via `usethis::use_github_action("lint-changed-files")`), and keeps whole-project linting for scheduled or manually triggered runs so drift is cleaned up deliberately in its own PR.

## Verification

- The r-lib/actions `lint-changed-files.yaml` example was fetched and confirmed to exist at the linked branch.
- Rendered `coding-style.qmd`: the new section lands as 7.13.4, a sibling of "Using Lintr" and "Our Lab's Lintr Configuration".
- New prose uses dictionary words only; no wordlist additions.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_