### PR TITLE
Add KISS principle section to coding practices

### DIFF
--- a/coding-practices.qmd
+++ b/coding-practices.qmd
@@ -64,6 +64,10 @@
 
 {{< include coding-practices/function-length-limits.qmd >}}
 
+## Keep It Short and Simple (KISS) {#sec-kiss}
+
+{{< include coding-practices/kiss-principle.qmd >}}
+
 ## The here package {#sec-here-package-practices}
 
 {{< include coding-practices/here-package.qmd >}}

--- a/coding-practices/kiss-principle.qmd
+++ b/coding-practices/kiss-principle.qmd
@@ -1,0 +1,34 @@
+The [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) ---
+"Keep It Short and Simple" ---
+says that most systems work best when they are kept simple,
+so unnecessary complexity should be avoided rather than managed.
+A more aggressive variant is the original
+"keep it simple, stupid,"
+coined by aircraft engineer Kelly Johnson at the Lockheed Skunk Works,
+whose standing challenge was that his team's aircraft
+must be repairable by an average mechanic in the field
+with only a handful of common tools.
+
+The principle carries directly into software development:
+code is read, debugged, and modified far more often than it is written,
+and it is usually maintained by someone with less context
+than the original author had ---
+often your own future self.
+
+Rationales for keeping code short and simple:
+
+- **Fewer bugs.** Less code and simpler control flow leave fewer places
+  for defects to hide and make the remaining logic easier to reason about.
+- **Easier review.** A reviewer can hold a short, single-purpose function
+  in their head; they cannot do that with a sprawling one.
+- **Cheaper maintenance.** Simple code can be modified confidently;
+  complex code makes every change risky and slow.
+- **Faster onboarding.** New lab members become productive sooner
+  when the codebase does things the plain, expected way.
+
+Simplicity is not an excuse to drop requirements:
+the goal is the simplest solution that still does the whole job,
+not a simpler job.
+The preceding sections on function decomposition and function length limits,
+and the guidance on [avoiding deep nesting](@sec-avoid-nesting),
+are concrete applications of this principle.

--- a/coding-practices/kiss-principle.qmd
+++ b/coding-practices/kiss-principle.qmd
@@ -2,10 +2,11 @@ The [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) ---
 "Keep It Short and Simple" ---
 says that most systems work best when they are kept simple,
 so unnecessary complexity should be avoided rather than managed.
-A more aggressive variant is the original
-"keep it simple, stupid,"
-coined by aircraft engineer Kelly Johnson at the Lockheed Skunk Works,
-whose standing challenge was that his team's aircraft
+A blunter phrasing ---
+the one aircraft engineer Kelly Johnson actually coined
+at the Lockheed Skunk Works ---
+is "keep it simple, stupid":
+his standing challenge was that his team's aircraft
 must be repairable by an average mechanic in the field
 with only a handful of common tools.
 


### PR DESCRIPTION
Closes #295

Adds a "Keep It Short and Simple (KISS)" section to the coding-practices chapter, per the issue's spec:

- Leads with the "Keep It Short and Simple" variant, then notes the original, more aggressive "keep it simple, stupid" coined by Kelly Johnson at the Lockheed Skunk Works (with his repairable-in-the-field design challenge as the origin story).
- Explains the software-development relevance: code is read/debugged/modified far more than written, usually by someone with less context than the author.
- Gives the supporting rationales: fewer bugs, easier review, cheaper maintenance, faster onboarding.
- Closes with the guardrail (simplest solution that does the whole job, not a simpler job) and points at the manual's concrete applications — the function decomposition and length-limit sections that precede it, and [avoiding deep nesting](https://ucd-serg.github.io/lab-manual/coding-style.html) via `@sec-avoid-nesting`.

Placed between "Function length limits" and "The here package" so the decomposition/length sections it references come earlier in reading order (no forward references).

## Verification

- Attribution facts (Johnson/Skunk Works origin, variant wording, software-development usage) checked against the cited [Wikipedia article](https://en.wikipedia.org/wiki/KISS_principle) via search (the proxy blocks direct Wikipedia fetches).
- Rendered the chapter: section and `@sec-avoid-nesting` crossref present; new file is ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_