### PR TITLE
docs: recommend Visualize.CRAN.Downloads for post-release download tracking

### DIFF
--- a/code-publication.qmd
+++ b/code-publication.qmd
@@ -242,3 +242,16 @@ Once CRAN accepts your package:
    git push
    ```
 
+4. **Track adoption over time**: the
+   [`{Visualize.CRAN.Downloads}`](https://github.com/mponce0/Visualize.CRAN.Downloads)
+   package plots a CRAN package's download counts
+   (retrieved via [`{cranlogs}`](https://r-hub.github.io/cranlogs/)),
+   producing static, interactive, and multi-package comparison plots,
+   with moving averages and confidence bands to make trends visible.
+   With no date range given,
+   it defaults to the year of downloads ending today:
+
+   ```r
+   Visualize.CRAN.Downloads::processPckg("yourpackage")
+   ```
+


### PR DESCRIPTION
Closes #296

Adds a fourth step to the "After CRAN Acceptance" list in the Code Publication chapter: track adoption with [`{Visualize.CRAN.Downloads}`](https://github.com/mponce0/Visualize.CRAN.Downloads), which plots a CRAN package's download counts (via `{cranlogs}`) as static, interactive, and multi-package comparison plots with moving averages and confidence bands.

## Verification

- The main function name (`processPckg` — not the more guessable `processPkg`) and all feature claims were checked against the package's README and NAMESPACE.
- The default-date-range claim (year ending today when no range is given) matches the README's "Automatic date specification" section.
- Rendered the chapter; the new step and code example appear; the added text is ASCII-only (the file's three pre-existing arrows on lines 146-150 are untouched and already pass check-chars on main).

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_