### PR TITLE
docs: document the Allow-Actions-to-create-PRs workflow permission

### DIFF
--- a/continuous-integration/setting-up-github-actions.qmd
+++ b/continuous-integration/setting-up-github-actions.qmd
@@ -41,3 +41,44 @@ usethis::use_github_action()
 #> 2: test-coverage: Compute test coverage and report to https://about.codecov.io
 #> 3: pr-commands: Add /document and /style commands for pull requests
 ```
+
+### Allowing Actions to Create Pull Requests
+
+Some workflows open pull requests themselves ---
+for example, a scheduled job that bumps a submodule pointer
+or updates generated files.
+By default, GitHub blocks workflows that authenticate
+with the built-in `GITHUB_TOKEN`
+from creating or approving pull requests,
+and such a workflow fails with a
+"GitHub Actions is not permitted to create or approve pull requests" error.
+
+To allow it, go to
+**Settings > Actions > General > Workflow permissions**
+in the repository
+and check **Allow GitHub Actions to create and approve pull requests**.
+
+A few related points:
+
+- The workflow also needs write access:
+  either select **Read and write permissions** on the same settings page,
+  or grant it per workflow with a `permissions:` block
+  (`contents: write` and `pull-requests: write`).
+- For repositories in an organization,
+  the same setting exists at the organization level,
+  and the organization setting must allow it
+  before the repository-level setting can take effect.
+- This governs only the built-in `GITHUB_TOKEN`;
+  workflows that authenticate with a personal access token
+  are governed by that token's own scopes instead.
+
+This repository's own `bump-ai-config.yml` workflow,
+which opens a weekly pull request to advance the `.ai-config` submodule,
+depends on this setting
+and grants itself the needed scopes with a `permissions:` block:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```

--- a/continuous-integration/setting-up-github-actions.qmd
+++ b/continuous-integration/setting-up-github-actions.qmd
@@ -75,10 +75,14 @@ A few related points:
 This repository's own `bump-ai-config.yml` workflow,
 which opens a weekly pull request to advance the `.ai-config` submodule,
 depends on this setting
-and grants itself the needed scopes with a `permissions:` block:
+and grants itself the needed scopes with a job-level `permissions:` block
+(the block can sit either at the top of a workflow file
+or under an individual job, as here):
 
 ```yaml
-permissions:
-  contents: write
-  pull-requests: write
+jobs:
+  bump:
+    permissions:
+      contents: write
+      pull-requests: write
 ```


### PR DESCRIPTION
Closes #298

Adds an "Allowing Actions to Create Pull Requests" subsection to the Continuous Integration chapter's "Setting Up GitHub Actions" section, covering:

- The **Settings > Actions > General > Workflow permissions** toggle ("Allow GitHub Actions to create and approve pull requests") the issue points at, and the "GitHub Actions is not permitted to create or approve pull requests" failure a PR-opening workflow hits without it.
- The companion write-access requirement — either "Read and write permissions" at the settings level or a per-workflow `permissions:` block (`contents: write`, `pull-requests: write`).
- The organization-level gate that must allow the setting before the repo-level toggle takes effect.
- The scope caveat: this governs only the built-in `GITHUB_TOKEN`; PAT-authenticated workflows follow the token's own scopes.

The concrete example is this repo's own `bump-ai-config.yml`, whose header comments document exactly this requirement and whose `permissions:` block is quoted verbatim.

## Verification

- Rendered the chapter; the new subsection appears under Setting Up GitHub Actions.
- Claims cross-checked against `bump-ai-config.yml` in this repo; new text is ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_