### PR TITLE
Add Quarto dashboards section to the Quarto chapter

### DIFF
--- a/quarto.qmd
+++ b/quarto.qmd
@@ -12,6 +12,10 @@
 
 {{< include quarto/books.qmd >}}
 
+## Dashboards {#sec-quarto-dashboards}
+
+{{< include quarto/dashboards.qmd >}}
+
 ## Quarto Profiles
 
 {{< include quarto/profiles.qmd >}}

--- a/quarto/dashboards.qmd
+++ b/quarto/dashboards.qmd
@@ -1,0 +1,28 @@
+[Quarto dashboards](https://quarto.org/docs/dashboards/) turn a `.qmd`
+(or Jupyter notebook) into a data dashboard
+by setting `format: dashboard` in the document YAML.
+
+Layout is driven by ordinary markdown headings,
+which define pages, rows, columns, and tabsets;
+each computational cell becomes a "card" holding a plot, table, or text.
+Value boxes highlight key metrics,
+and sidebars and toolbars hold interactive inputs.
+
+Dashboards work with R, Python, Julia, and Observable JavaScript,
+and display both interactive widgets
+([`{plotly}`](https://plotly.com/r/), [`{leaflet}`](https://rstudio.github.io/leaflet/), htmlwidgets)
+and static graphics ([`{ggplot2}`](https://ggplot2.tidyverse.org/), Matplotlib).
+
+By default a dashboard renders to static HTML,
+so it can be published anywhere a web page can
+(including GitHub Pages, like the rest of our Quarto output)
+with no server behind it.
+When server-side interactivity is genuinely needed,
+a [Shiny](https://shiny.posit.co/) backend can drive the dashboard,
+at the cost of needing a Shiny server to host it.
+For most lab reporting,
+start with the static form and add Shiny only if filtering or
+recomputation on the reader's side becomes necessary.
+
+See the [dashboard examples gallery](https://quarto.org/docs/gallery/#dashboards)
+for layouts to copy from.

--- a/quarto/dashboards.qmd
+++ b/quarto/dashboards.qmd
@@ -10,8 +10,8 @@ and sidebars and toolbars hold interactive inputs.
 
 Dashboards work with R, Python, Julia, and Observable JavaScript,
 and display both interactive widgets
-([`{plotly}`](https://plotly.com/r/), [`{leaflet}`](https://rstudio.github.io/leaflet/), htmlwidgets)
-and static graphics ([`{ggplot2}`](https://ggplot2.tidyverse.org/), Matplotlib).
+([`{plotly}`](https://plotly.com/r/), [`{leaflet}`](https://rstudio.github.io/leaflet/), [`{htmlwidgets}`](https://www.htmlwidgets.org/))
+and static graphics ([`{ggplot2}`](https://ggplot2.tidyverse.org/), `Matplotlib`).
 
 By default a dashboard renders to static HTML,
 so it can be published anywhere a web page can


### PR DESCRIPTION
Closes #299

Adds a "Dashboards" section to the Quarto chapter (new `quarto/dashboards.qmd` fragment, placed after Building Quarto Books), summarizing [quarto.org/docs/dashboards](https://quarto.org/docs/dashboards/):

- `format: dashboard` in the document YAML; works from `.qmd` or Jupyter notebooks.
- Heading-driven layout — pages, rows, columns, tabsets — with each computational cell becoming a card; value boxes for metrics; sidebars/toolbars for inputs.
- Engine support (R, Python, Julia, Observable JS) and both interactive (plotly, leaflet, htmlwidgets) and static (ggplot2, Matplotlib) graphics.
- Deployment guidance oriented to the lab's setup: static HTML by default (publishable on GitHub Pages like the rest of our Quarto output), with a Shiny backend only when server-side interactivity is genuinely needed.
- Pointer to the dashboards examples gallery.

## Verification

- Claims checked against the live quarto.org dashboards page (fetched during drafting).
- Rendered the chapter: new section and links present; new text is ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_