### PR TITLE
docs: catalog reusable GitHub Actions collections for R repos

### DIFF
--- a/continuous-integration.qmd
+++ b/continuous-integration.qmd
@@ -8,7 +8,7 @@
 
 {{< include continuous-integration/action-versioning.qmd >}}
 
-## Setting Up GitHub Actions
+## Setting Up GitHub Actions {#sec-setting-up-github-actions}
 
 {{< include continuous-integration/setting-up-github-actions.qmd >}}
 

--- a/continuous-integration.qmd
+++ b/continuous-integration.qmd
@@ -12,6 +12,10 @@
 
 {{< include continuous-integration/setting-up-github-actions.qmd >}}
 
+## Reusable Workflow Collections {#sec-reusable-workflow-collections}
+
+{{< include continuous-integration/reusable-workflow-collections.qmd >}}
+
 ## How GitHub Actions Workflows Work
 
 {{< include continuous-integration/how-workflows-work.qmd >}}

--- a/continuous-integration/reusable-workflow-collections.qmd
+++ b/continuous-integration/reusable-workflow-collections.qmd
@@ -1,0 +1,32 @@
+Several repositories collect reusable GitHub Actions and workflows for R projects,
+so you can call battle-tested CI steps instead of writing your own:
+
+- [d-morrison/gha](https://github.com/d-morrison/gha):
+  our lab's own collection of composite actions and reusable workflows
+  for R-package and Quarto repositories,
+  covering previews, publishing, test coverage, spell/link/character checks,
+  bibliography DOI checks, and the Claude review bots used across our repos.
+- [r-lib/actions](https://github.com/r-lib/actions):
+  the tidyverse team's actions and example workflows
+  (`R CMD check`, test coverage, pkgdown, lint),
+  installable with `usethis::use_github_action()`
+  as described earlier in this chapter.
+- [eddelbuettel/r-ci](https://github.com/eddelbuettel/r-ci):
+  a portable, shell-script-based CI setup for R
+  that works across GitHub Actions, Azure DevOps, Docker,
+  and other providers from one configuration;
+  the successor to the r-travis project.
+- [easystats/workflows](https://github.com/easystats/workflows):
+  reusable workflows the easystats collective runs across its R packages,
+  useful as worked examples of centralizing many repos' automation
+  in one place.
+- [RMI-PACTA/actions](https://github.com/RMI-PACTA/actions):
+  R and Docker actions plus example caller workflows;
+  now archived ("no new work is expected"),
+  but still readable as a reference for structuring an actions repo.
+
+When several of your repositories need the same workflow,
+prefer calling a shared collection (or adding to ours)
+over copying workflow files between repos,
+for the same reason we avoid copy-pasted functions:
+fixes and improvements then land everywhere at once.

--- a/continuous-integration/reusable-workflow-collections.qmd
+++ b/continuous-integration/reusable-workflow-collections.qmd
@@ -1,5 +1,5 @@
 Several repositories collect reusable GitHub Actions and workflows for R projects,
-so you can call battle-tested CI steps instead of writing your own:
+so you can call shared, community-maintained CI steps instead of writing your own:
 
 - [d-morrison/gha](https://github.com/d-morrison/gha):
   our lab's own collection of composite actions and reusable workflows
@@ -8,9 +8,9 @@ so you can call battle-tested CI steps instead of writing your own:
   bibliography DOI checks, and the Claude review bots used across our repos.
 - [r-lib/actions](https://github.com/r-lib/actions):
   the tidyverse team's actions and example workflows
-  (`R CMD check`, test coverage, pkgdown, lint),
+  (`R CMD check`, test coverage, [`{pkgdown}`](https://pkgdown.r-lib.org/), [`{lintr}`](https://lintr.r-lib.org/)),
   installable with `usethis::use_github_action()`
-  as described earlier in this chapter.
+  as described in @sec-setting-up-github-actions.
 - [eddelbuettel/r-ci](https://github.com/eddelbuettel/r-ci):
   a portable, shell-script-based CI setup for R
   that works across GitHub Actions, Azure DevOps, Docker,


### PR DESCRIPTION
Closes #300

Adds a "Reusable Workflow Collections" section to the Continuous Integration chapter (new `continuous-integration/reusable-workflow-collections.qmd` fragment, placed after Setting Up GitHub Actions), cataloging the repos the issue lists plus the lab's own:

- **d-morrison/gha** — the lab's composite actions and reusable workflows (previews, publishing, coverage, spell/link/char/DOI checks, Claude review bots).
- **r-lib/actions** — the tidyverse team's actions/examples, tied back to the `usethis::use_github_action()` guidance earlier in the chapter.
- **eddelbuettel/r-ci** — portable shell-based CI across GitHub Actions/Azure/Docker; successor to r-travis.
- **easystats/workflows** — a worked example of centralizing many repos' automation.
- **RMI-PACTA/actions** — listed with the caveat that it's archived ("no new work is expected" per its README), kept as a structural reference.

Ends with the DRY framing: prefer calling a shared collection over copying workflow files between repos.

## Verification

- Every description was checked against the repo's own README (fetched during drafting); the archived status of RMI-PACTA/actions comes from its README banner.
- Branch is cut from post-#400/#406/#407 main. Rendered the chapter: section and all links present; new text is ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_