### PR TITLE
docs: add GitLab notes to the GitHub chapter

### DIFF
--- a/github.qmd
+++ b/github.qmd
@@ -189,6 +189,10 @@ Never push .Rout files! If someone else runs an R script and creates an .Rout fi
 
 There is a standardized `.gitignore` for `R` which you [can download](https://github.com/github/gitignore/blob/master/R.gitignore) and add to your project. This ensures you're not committing log files or things that would otherwise best be left ignored to GitHub. This is a [great discussion of project-oriented workflows](https://tidyverse.org/blog/2017/12/workflow-vs-script/), extolling the virtues of a self-contained, portable projects, for your reference.
 
+## GitLab {#sec-gitlab}
+
+{{< include github/_sec-gitlab.qmd >}}
+
 ## Customizing How Files Appear on GitHub {#sec-gitattributes}
 
 {{< include github/_sec-gitattributes.qmd >}}

--- a/github/_sec-gitlab.qmd
+++ b/github/_sec-gitlab.qmd
@@ -1,0 +1,34 @@
+Our lab primarily uses GitHub,
+but you may encounter [GitLab](https://about.gitlab.com/) ---
+most often when collaborating with a group
+that self-hosts its own GitLab instance.
+
+The two platforms support the same core workflow
+(clone, branch, push, review, merge),
+with a few differences worth knowing:
+
+- **Terminology.** A GitHub *pull request* is a GitLab *merge request* (MR);
+  the concept is identical.
+- **Hosting.** GitLab is open-core and designed for self-hosting,
+  so organizations often run their own instance behind their firewall;
+  GitHub repositories almost always live on github.com.
+- **Continuous integration.** GitLab ships a built-in CI/CD system
+  configured by a single `.gitlab-ci.yml` file at the repository root,
+  where GitHub uses GitHub Actions workflows under `.github/workflows/`
+  (see @sec-r-ci).
+- **Command-line tool.** `glab` is the GitLab counterpart to `gh`;
+  installation and authentication are covered in @sec-cli-tools.
+
+Two R packages help when working with GitLab from R:
+
+- [`{gitlabr}`](https://github.com/ThinkR-open/gitlabr)
+  provides R access to the GitLab API,
+  with convenience wrappers for common tasks
+  (repository file access, issue assignment and status, commenting).
+- [`{pr.helpers}`](https://github.com/d-morrison/pr.helpers),
+  our lab's own (experimental) package,
+  provides helpers for common pull/merge request workflows
+  from a local Git repository ---
+  creating and switching branches, fetching requests by number,
+  generating request URLs, and syncing with the default branch ---
+  and works across both GitHub and GitLab remotes.

--- a/github/_sec-gitlab.qmd
+++ b/github/_sec-gitlab.qmd
@@ -19,7 +19,8 @@ with a few differences worth knowing:
 - **Command-line tool.** `glab` is the GitLab counterpart to `gh`;
   installation and authentication are covered in @sec-cli-tools.
 
-Two R packages help when working with GitLab from R:
+Two R packages help when working with GitLab from R
+(the second works across both forges):
 
 - [`{gitlabr}`](https://github.com/ThinkR-open/gitlabr)
   provides R access to the GitLab API,

--- a/github/_sec-gitlab.qmd
+++ b/github/_sec-gitlab.qmd
@@ -22,7 +22,7 @@ with a few differences worth knowing:
 Two R packages help when working with GitLab from R
 (the second works across both forges):
 
-- [`{gitlabr}`](https://github.com/ThinkR-open/gitlabr)
+- [`{gitlabr}`](https://thinkr-open.github.io/gitlabr/)
   provides R access to the GitLab API,
   with convenience wrappers for common tasks
   (repository file access, issue assignment and status, commenting).


### PR DESCRIPTION
Closes #302

Adds a "GitLab" section to the GitHub chapter (new `github/_sec-gitlab.qmd` fragment, placed before the gitattributes section), covering the issue's three asks:

- **How it differs from GitHub**: merge-request vs pull-request terminology, self-hosting as the common reason the lab encounters GitLab, built-in CI via `.gitlab-ci.yml` (crossref to `@sec-r-ci`) vs GitHub Actions, and `glab` as the `gh` counterpart (crossref to `@sec-cli-tools`, which already documents installing it).
- **[`{gitlabr}`](https://github.com/ThinkR-open/gitlabr)**: R access to the GitLab API with convenience wrappers — description matches its DESCRIPTION.
- **[`{pr.helpers}`](https://github.com/d-morrison/pr.helpers)**: the lab's own cross-forge PR/MR workflow helpers, noted as experimental per its lifecycle badge — description matches its DESCRIPTION.

## Verification

- Both package descriptions checked against the fetched DESCRIPTION files.
- Branch cut from post-#400/#406/#407 main; rendered the chapter — section, crossrefs, and links all present; new text is ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_