### PR TITLE
Add Architecture Decision Records guidance to coding practices

### DIFF
--- a/coding-practices.qmd
+++ b/coding-practices.qmd
@@ -48,6 +48,10 @@
 
 {{< include coding-practices/documenting-code.qmd >}}
 
+## Design Documentation with ADRs {#sec-adrs}
+
+{{< include coding-practices/architecture-decision-records.qmd >}}
+
 ## Object naming
 
 {{< include coding-practices/object-naming.qmd >}}

--- a/coding-practices/architecture-decision-records.qmd
+++ b/coding-practices/architecture-decision-records.qmd
@@ -39,7 +39,7 @@ so they are versioned, reviewable, and greppable alongside the code.
 
 **How to reference them from code.**
 Point to the ADR with a terse inline comment ---
-`# see docs/adr-wip-lock.md, "Locking" section` ---
+`# see docs/adr-<topic>.md, "<section>" section` ---
 instead of duplicating the rationale in comments.
 This keeps scripts readable while making the full reasoning
 one hop away,

--- a/coding-practices/architecture-decision-records.qmd
+++ b/coding-practices/architecture-decision-records.qmd
@@ -9,7 +9,8 @@ an ADR explains a *decision* that shapes many files at once
 and would otherwise live only in someone's memory
 or a long-merged pull request thread.
 
-**When to write one.**
+### When to write one {#sec-adr-when}
+
 Write an ADR for a non-obvious design choice that affects
 multiple files or systems:
 a concurrency or security trade-off,
@@ -18,7 +19,8 @@ or a naming convention that needs justification.
 Routine choices that any reader would make the same way
 do not need one.
 
-**Recommended format.**
+### Recommended format {#sec-adr-format}
+
 Use the four-part template from
 [Michael Nygard's "Documenting Architecture Decisions"](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
 
@@ -31,13 +33,15 @@ Use the four-part template from
 - **Consequences**: what becomes easier, what becomes harder,
   and what future work the decision commits you to.
 
-**Where to store them.**
+### Where to store them {#sec-adr-storage}
+
 Keep ADRs in the repository they describe,
 as `docs/adr-<topic>.md` files
 (or a `docs/decisions/` directory once there are more than a few),
 so they are versioned, reviewable, and greppable alongside the code.
 
-**How to reference them from code.**
+### How to reference them from code {#sec-adr-code-pointers}
+
 Point to the ADR with a terse inline comment ---
 `# see docs/adr-<topic>.md, "<section>" section` ---
 instead of duplicating the rationale in comments.
@@ -46,7 +50,8 @@ one hop away,
 and it means the rationale has one home to update
 when the decision changes.
 
-**Relationship to pull request descriptions.**
+### Relationship to pull request descriptions {#sec-adr-vs-pr}
+
 A PR description explains *why this change, now*,
 and effectively disappears from view once the PR merges;
 an ADR persists in the repository

--- a/coding-practices/architecture-decision-records.qmd
+++ b/coding-practices/architecture-decision-records.qmd
@@ -1,0 +1,57 @@
+An Architecture Decision Record (ADR) is a short, versioned document
+that captures a significant design decision:
+the context that forced the choice,
+the alternatives considered,
+the decision itself,
+and its consequences.
+Function-level documentation and inline comments explain *code*;
+an ADR explains a *decision* that shapes many files at once
+and would otherwise live only in someone's memory
+or a long-merged pull request thread.
+
+**When to write one.**
+Write an ADR for a non-obvious design choice that affects
+multiple files or systems:
+a concurrency or security trade-off,
+a data layout or dependency choice with long-term consequences,
+or a naming convention that needs justification.
+Routine choices that any reader would make the same way
+do not need one.
+
+**Recommended format.**
+Use the four-part template from
+[Michael Nygard's "Documenting Architecture Decisions"](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+
+- **Status**: proposed, accepted, deprecated, or superseded
+  (with a pointer to the successor).
+- **Context**: the forces at play ---
+  what problem existed and what constraints applied.
+- **Decision**: what was chosen, stated in full sentences
+  with an active voice ("We will ...").
+- **Consequences**: what becomes easier, what becomes harder,
+  and what future work the decision commits you to.
+
+**Where to store them.**
+Keep ADRs in the repository they describe,
+as `docs/adr-<topic>.md` files
+(or a `docs/decisions/` directory once there are more than a few),
+so they are versioned, reviewable, and greppable alongside the code.
+
+**How to reference them from code.**
+Point to the ADR with a terse inline comment ---
+`# see docs/adr-wip-lock.md, "Locking" section` ---
+instead of duplicating the rationale in comments.
+This keeps scripts readable while making the full reasoning
+one hop away,
+and it means the rationale has one home to update
+when the decision changes.
+
+**Relationship to pull request descriptions.**
+A PR description explains *why this change, now*,
+and effectively disappears from view once the PR merges;
+an ADR persists in the repository
+and keeps answering "why is it built this way?"
+long after the merge.
+When a PR implements a significant decision,
+write the ADR in that PR
+and let the PR description summarize and link to it.


### PR DESCRIPTION
Closes #306

Adds a "Design Documentation with ADRs" section to the coding-practices chapter (new `coding-practices/architecture-decision-records.qmd` fragment, placed right after "Documenting your code"), covering all six points from the issue:

1. **What an ADR is** — a short versioned document capturing a decision's context, alternatives, choice, and consequences, contrasted with code-level documentation.
2. **When to write one** — non-obvious choices spanning multiple files/systems (concurrency/security trade-offs, justification-needing conventions), with the routine-choice exclusion.
3. **Format** — [Nygard's Status/Context/Decision/Consequences template](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions), cited.
4. **Storage** — `docs/adr-<topic>.md`, graduating to `docs/decisions/` at volume.
5. **Referencing from code** — terse inline pointers (using the `adr-wip-lock.md` style example from the motivating review) instead of duplicated rationale.
6. **Relationship to PR descriptions** — PR text is ephemeral after merge; the ADR persists, with the write-the-ADR-in-the-implementing-PR pattern.

## Verification

- Branch cut from post-#400/#406/#407 main; insertion point doesn't collide with #416/#417's pending inserts elsewhere in the same chapter file.
- Rendered the chapter: section present, Nygard link present, ASCII-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_