### PR TITLE
Add {snapr} blurb to the snapshot-testing guidance

### DIFF
--- a/coding-practices/testing-requirements.qmd
+++ b/coding-practices/testing-requirements.qmd
@@ -15,6 +15,23 @@ test_that("prep_study_data produces expected structure", {
 })
 ```
 
+Our lab's [`{snapr}`](https://d-morrison.github.io/snapr/) package
+(on [CRAN](https://cran.r-project.org/package=snapr))
+adds convenience wrappers on top of
+[`{testthat}`](https://testthat.r-lib.org/)'s snapshot functions:
+`expect_snapshot_data()` for data frames
+(adapted, with permission, from the
+[`{ssdtools}`](https://cran.r-project.org/package=ssdtools) package)
+and `expect_snapshot_object()`,
+which generalizes it to any R object.
+
+```r
+test_that("prep_study_data output is stable", {
+  result <- prep_study_data(raw_data)
+  snapr::expect_snapshot_data(result, name = "prepped_study_data")
+})
+```
+
 ### When to Use Explicit Value Tests
 
 Use explicit tests (`expect_equal()`, `expect_identical()`) when:


### PR DESCRIPTION
Closes #320

Adds a [`{snapr}`](https://d-morrison.github.io/snapr/) blurb to the Testing Requirements section's "When to Use Snapshot Tests" subsection, right after the existing `expect_snapshot_value()` example:

- Introduces the lab's snapr package (on CRAN) as convenience wrappers over `{testthat}` snapshots
- Names its two expectation functions — `expect_snapshot_data()` (adapted with permission from `{ssdtools}`) and `expect_snapshot_object()` — and adds a short usage example

## Verification

All claims checked against the package's own sources: DESCRIPTION (title, CRAN/pkgdown URLs), NAMESPACE (both exports), and README (the ssdtools provenance with its linked permission issue, the `name =` argument in the example signature, CRAN badges).