### PR TITLE
Summarize test-driven development

### DIFF
--- a/coding-practices.qmd
+++ b/coding-practices.qmd
@@ -20,6 +20,10 @@
 
 {{< include coding-practices/testing-requirements.qmd >}}
 
+## Test-Driven Development {#sec-tdd}
+
+{{< include coding-practices/test-driven-development.qmd >}}
+
 ## Benchmarking {#sec-benchmarking}
 
 {{< include coding-practices/benchmarking.qmd >}}
@@ -56,7 +60,7 @@
 
 {{< include coding-practices/function-calls.qmd >}}
 
-## Function decomposition
+## Function decomposition {#sec-function-decomposition}
 
 {{< include coding-practices/function-decomposition.qmd >}}
 

--- a/coding-practices/test-driven-development.qmd
+++ b/coding-practices/test-driven-development.qmd
@@ -1,0 +1,45 @@
+[Test-driven development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development)
+inverts the usual order of coding and testing:
+you write the test for a behavior *before*
+writing the code that implements it.
+The practice was popularized by Kent Beck,
+who developed it as part of extreme programming
+and described it in
+*Test-Driven Development: By Example* (2002).
+
+Work proceeds in a short, repeated cycle
+(often called *red-green-refactor*):
+
+1. **Red.**
+   Write a small test for the next behavior you want,
+   and run it to confirm it fails ---
+   this proves the test can actually detect the missing behavior.
+2. **Green.**
+   Write the simplest code that makes the test pass,
+   resisting the urge to build ahead of the tests.
+3. **Refactor.**
+   Clean up the code (and the tests) while everything stays green,
+   leaning on the tests to catch anything the cleanup breaks.
+
+Why it helps:
+
+- The test pins down what the function *should* do
+  before you are invested in what it happens to do,
+  turning requirements into executable checks.
+- Every unit of behavior ends up covered by construction,
+  so later changes get regression protection for free.
+- Code written to be testable tends toward
+  small, single-purpose functions with explicit inputs and outputs ---
+  the same design our function-decomposition
+  (@sec-function-decomposition) guidance pushes toward.
+
+You do not have to practice strict TDD to benefit from it.
+Our testing guidance (@sec-r-testing) already applies its core move ---
+establish tests *before* modifying existing functions ---
+and writing the test first is just that same discipline
+applied to new code as well.
+In R packages, the mechanics are light:
+`usethis::use_test()` creates the matching
+[`{testthat}`](https://testthat.r-lib.org/) test file for a function,
+and `devtools::test()` runs the suite
+(see [R Packages, ch. "Testing basics"](https://r-pkgs.org/testing-basics.html)).

--- a/coding-practices/test-driven-development.qmd
+++ b/coding-practices/test-driven-development.qmd
@@ -40,6 +40,6 @@ and writing the test first is just that same discipline
 applied to new code as well.
 In R packages, the mechanics are light:
 `usethis::use_test()` creates the matching
-[`{testthat}`](https://testthat.r-lib.org/) test file for a function,
+[`{testthat}`](https://testthat.r-lib.org/) test file,
 and `devtools::test()` runs the suite
 (see [R Packages, ch. "Testing basics"](https://r-pkgs.org/testing-basics.html)).


### PR DESCRIPTION
Closes #324

Adds a "Test-Driven Development" section to the R Coding Practices chapter (`coding-practices/test-driven-development.qmd`, wired in as `## Test-Driven Development {#sec-tdd}` right after "Testing Requirements"):

- The red-green-refactor cycle, with the reason for running the failing test first
- Provenance: popularized by Kent Beck via extreme programming and *Test-Driven Development: By Example* (2002), per the [Wikipedia article](https://en.wikipedia.org/wiki/Test-driven_development) the issue cites
- Why it helps: executable requirements, regression protection by construction, design pressure toward small testable functions (crossref `@sec-function-decomposition`)
- The lab tie-in: our existing "establish tests before modifying functions" rule (`@sec-r-testing`) is the same discipline; R mechanics via `usethis::use_test()` / `devtools::test()` with a link to [R Packages' testing chapter](https://r-pkgs.org/testing-basics.html)

Coordination note: this PR adds `{#sec-function-decomposition}` to the existing "Function decomposition" heading for its crossref. PR #426 adds the **identical** id at the same spot, so whichever merges second gets a clean automatic merge rather than a conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_