### PR TITLE
Explain the personal dev branch workflow

### DIFF
--- a/github.qmd
+++ b/github.qmd
@@ -98,6 +98,10 @@ Branches allow you to keep track of multiple versions of your work simultaneousl
 
 A detailed tutorial on Git Branching can be found [here](https://sp19.datastructur.es/materials/guides/using-git#e-git-branching-advanced-git-optional). You can also find instructions on how to handle merge conflicts when joining branches together.
 
+## Personal Dev Branches {#sec-dev-branches}
+
+{{< include github/_sec-dev-branches.qmd >}}
+
 ## Example Workflow
 
 A standard workflow when starting on a new project and contributing code looks like this:

--- a/github/_sec-dev-branches.qmd
+++ b/github/_sec-dev-branches.qmd
@@ -1,0 +1,51 @@
+Feature branches work best when each one stays small and scoped,
+but day-to-day exploratory work does not arrive in tidy, scoped units.
+Personal dev branches let you have both.
+
+Each developer can keep a long-lived personal branch ---
+named after them, for example `dev-ezra` ---
+that they push to freely:
+experiments, half-finished ideas, notes-to-self,
+and fixes for whatever they bump into along the way.
+Nobody reviews a dev branch and nothing merges from it directly,
+so there is no pressure to keep it clean.
+
+When some of that work is ready to contribute back to `main`:
+
+1. Start a *new* feature branch from the **current** `main`
+   (not from the dev branch).
+2. Cherry-pick the commits you want to contribute
+   from the dev branch onto the feature branch.
+3. Open a pull request from the feature branch onto `main`
+   as usual.
+
+```bash
+# daily work: push freely
+git switch dev-ezra
+
+# ready to contribute: branch from current main ...
+git fetch origin
+git switch -c feat-cleaning-helpers origin/main
+
+# ... pull over just the commits that belong in this contribution
+git log --oneline dev-ezra           # find the commit hashes
+git cherry-pick <hash1> <hash2>
+
+git push -u origin feat-cleaning-helpers
+# then open the PR from feat-cleaning-helpers onto main
+```
+
+This way you can flow naturally while working ---
+no stopping to plan a minimal, modular pull request in advance ---
+and still deliver PRs that are minimal and modular,
+because the scoping happens at cherry-pick time instead.
+
+Two habits make the cherry-picking step painless:
+
+- **Commit in small, single-topic units on your dev branch.**
+  A commit that mixes two unrelated changes
+  cannot be cherry-picked into two different PRs.
+- **Sync the dev branch with `main` periodically**
+  (`git merge origin/main`),
+  so your experiments build on current code
+  and your cherry-picks transplant cleanly.

--- a/github/_sec-dev-branches.qmd
+++ b/github/_sec-dev-branches.qmd
@@ -39,6 +39,11 @@ git push -u origin feat-cleaning-helpers
 # then open the PR from feat-cleaning-helpers onto main
 ```
 
+(`git switch` is the modern, branch-only successor to `git checkout`;
+`git checkout dev-ezra` and `git checkout -b feat-cleaning-helpers origin/main`,
+matching the commands used elsewhere in this chapter,
+do the same thing.)
+
 This way you can flow naturally while working ---
 no stopping to plan a minimal, modular pull request in advance ---
 and still deliver PRs that are minimal and modular,

--- a/github/_sec-dev-branches.qmd
+++ b/github/_sec-dev-branches.qmd
@@ -20,6 +20,10 @@ When some of that work is ready to contribute back to `main`:
    as usual.
 
 ```bash
+# one-time setup: create your personal dev branch from current main
+git switch -c dev-ezra origin/main
+git push -u origin dev-ezra
+
 # daily work: push freely
 git switch dev-ezra
 


### PR DESCRIPTION
Closes #341

Adds a "Personal Dev Branches" section to the GitHub chapter (`github/_sec-dev-branches.qmd`, wired in as `## Personal Dev Branches {#sec-dev-branches}` between "Git Branching" and "Example Workflow"), documenting the workflow from the issue:

- Each developer keeps a long-lived personal branch (e.g. `dev-ezra`) they push to freely — no review pressure, no cleanliness pressure
- To contribute back: cut a **new** feature branch from **current** `main`, cherry-pick the relevant commits from the dev branch, and open the PR from the feature branch
- The payoff, as the issue puts it: developers flow naturally without stopping to plan minimal, modular PRs — the scoping happens at cherry-pick time
- Plus the two habits that keep cherry-picking painless: small single-topic commits, and periodically syncing the dev branch with `main`

Includes the concrete command sequence (`git switch`, `git switch -c feat-... origin/main`, `git log --oneline`, `git cherry-pick`, `git push -u`).

Placement note: inserted between "Git Branching" and "Example Workflow", clear of PR #422's insertion point later in the same file, so the two merge cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_018g1kZPGJRqAV3mEPJ3BTE6)_