### PR TITLE
Use class assertions in unit test condition expectations

### DIFF
--- a/coding-practices/testing-requirements.qmd
+++ b/coding-practices/testing-requirements.qmd
@@ -118,14 +118,14 @@ test_that("prep_study_data handles edge cases", {
     prep_study_data(data.frame()),
     class = "prep_study_data_empty_input_error"
   )
-  
+
   # Missing required columns
   expect_error(
     prep_study_data(data.frame(x = 1)),
     class = "prep_study_data_missing_columns_error",
     regexp = "Missing required columns"
   )
-  
+
   # Valid input with missing values
   result <- prep_study_data(data.frame(id = 1:3, value = c(1, NA, 3)))
   expect_true(all(!is.na(result$value)))

--- a/coding-practices/testing-requirements.qmd
+++ b/coding-practices/testing-requirements.qmd
@@ -106,13 +106,25 @@ in more depth.
 - **Test edge cases**: Missing values, empty inputs, boundary conditions
 - **Test errors**: Verify functions fail appropriately with invalid input
 
+When testing conditions with [`{testthat}`](https://testthat.r-lib.org/),
+assert on the condition `class` whenever possible.
+Message text (`regexp`) can be checked as a secondary assertion,
+but should not be the only signal.
+
 ```r
 test_that("prep_study_data handles edge cases", {
   # Empty input
-  expect_error(prep_study_data(data.frame()))
+  expect_error(
+    prep_study_data(data.frame()),
+    class = "prep_study_data_empty_input_error"
+  )
   
   # Missing required columns
-  expect_error(prep_study_data(data.frame(x = 1)))
+  expect_error(
+    prep_study_data(data.frame(x = 1)),
+    class = "prep_study_data_missing_columns_error",
+    regexp = "Missing required columns"
+  )
   
   # Valid input with missing values
   result <- prep_study_data(data.frame(id = 1:3, value = c(1, NA, 3)))

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -1,0 +1,61 @@
+#' Condition-class linter for testthat expectations
+#'
+#' Flags `expect_error()`, `expect_warning()`, and `expect_message()` calls
+#' that assert on message text (`regexp =` or positional `regexp`) without
+#' also asserting on a condition `class =`.
+#'
+#' Matching only error or warning text is brittle:
+#' wording can change while the underlying condition type stays correct.
+#' Prefer asserting the class, and optionally add `regexp =` for extra precision.
+#'
+#' @return A [lintr::Linter()] object.
+#' @noRd
+condition_class_linter <- function() {
+  target_functions <- c("expect_error", "expect_warning", "expect_message")
+  calls_xpath <- paste(
+    "//SYMBOL_FUNCTION_CALL[text() = ",
+    paste(sprintf("'%s'", target_functions), collapse = " or text() = "),
+    "]/ancestor::expr[OP-LEFT-PAREN][1]",
+    sep = ""
+  )
+
+  lintr::Linter(linter_level = "expression", function(source_expression) {
+    if (!lintr::is_lint_level(source_expression, "expression")) {
+      return(list())
+    }
+
+    calls <- xml2::xml_find_all(
+      source_expression$xml_parsed_content,
+      calls_xpath
+    )
+    if (!length(calls)) {
+      return(list())
+    }
+
+    needs_class <- vapply(calls, function(call) {
+      arg_names <- xml2::xml_text(xml2::xml_find_all(call, "./SYMBOL_SUB"))
+      has_class <- "class" %in% arg_names
+      has_named_regexp <- "regexp" %in% arg_names
+
+      first_after_comma <- xml2::xml_find_first(
+        call,
+        "./OP-COMMA[1]/following-sibling::*[1]"
+      )
+      has_positional_regexp <- !inherits(first_after_comma, "xml_missing") &&
+        identical(xml2::xml_name(first_after_comma), "expr")
+
+      !has_class && (has_named_regexp || has_positional_regexp)
+    }, logical(1))
+
+    lintr::xml_nodes_to_lints(
+      calls[needs_class],
+      source_expression = source_expression,
+      lint_message = paste(
+        "When matching a condition message in `expect_error()`,",
+        "`expect_warning()`, or `expect_message()`, include a `class =`",
+        "assertion instead of relying on `regexp` alone."
+      ),
+      type = "warning"
+    )
+  })
+}

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -6,7 +6,8 @@
 #'
 #' Matching only error or warning text is brittle:
 #' wording can change while the underlying condition type stays correct.
-#' Prefer asserting the class, and optionally add `regexp =` for extra precision.
+#' Prefer asserting the class,
+#' and optionally add `regexp =` for extra precision.
 #'
 #' @return A [lintr::Linter()] object.
 #' @noRd

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -38,12 +38,11 @@ condition_class_linter <- function() {
       has_class <- "class" %in% arg_names
       has_named_regexp <- "regexp" %in% arg_names
 
-      first_after_comma <- xml2::xml_find_first(
+      positional_regexp <- xml2::xml_find_first(
         call,
-        "./OP-COMMA[1]/following-sibling::*[1]"
+        "./expr[3][preceding-sibling::*[1][self::OP-COMMA]]"
       )
-      has_positional_regexp <- !inherits(first_after_comma, "xml_missing") &&
-        identical(xml2::xml_name(first_after_comma), "expr")
+      has_positional_regexp <- !inherits(positional_regexp, "xml_missing")
 
       !has_class && (has_named_regexp || has_positional_regexp)
     }, logical(1))

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -4,7 +4,7 @@
 #' that assert on message text (`regexp =` or positional `regexp`) without
 #' also asserting on a condition `class =`.
 #'
-#' Matching only error or warning text is brittle:
+#' Matching only condition or message text is brittle:
 #' wording can change while the underlying condition type stays correct.
 #' Prefer asserting the class,
 #' and optionally add `regexp =` for extra precision.

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -40,6 +40,8 @@ condition_class_linter <- function() {
 
       # The second positional argument is the third direct `expr` child:
       # function call, first argument, then unnamed `regexp`.
+      # Requiring an immediate preceding comma excludes named arguments,
+      # whose value expression is preceded by `EQ_SUB` instead.
       positional_regexp <- xml2::xml_find_first(
         call,
         "./expr[3][preceding-sibling::*[1][self::OP-COMMA]]"

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -4,7 +4,7 @@
 #' that assert on message text (`regexp =` or positional `regexp`) without
 #' also asserting on a condition `class =`.
 #'
-#' Matching only condition or message text is brittle:
+#' Matching only message text is brittle:
 #' wording can change while the underlying condition type stays correct.
 #' Prefer asserting the class,
 #' and optionally add `regexp =` for extra precision.

--- a/lms/R/condition_class_linter.R
+++ b/lms/R/condition_class_linter.R
@@ -38,6 +38,8 @@ condition_class_linter <- function() {
       has_class <- "class" %in% arg_names
       has_named_regexp <- "regexp" %in% arg_names
 
+      # The second positional argument is the third direct `expr` child:
+      # function call, first argument, then unnamed `regexp`.
       positional_regexp <- xml2::xml_find_first(
         call,
         "./expr[3][preceding-sibling::*[1][self::OP-COMMA]]"

--- a/lms/R/linters.R
+++ b/lms/R/linters.R
@@ -143,6 +143,7 @@ default_linters <- function() {
     ),
     lintr::cyclocomp_linter(),
     function_length_linter(),
-    function_location_linter()
+    function_location_linter(),
+    condition_class_linter()
   )
 }

--- a/lms/README.md
+++ b/lms/README.md
@@ -9,7 +9,8 @@ It lives in the `lms/` subdirectory of
 
 - `default_linters()` — the canonical linter set (`lintr::linters_with_defaults()`
   plus the lab's rules: `|>` pipe consistency, snake_case-with-acronyms object names,
-  and `cli::`-oriented undesirable functions).
+  `cli::`-oriented undesirable functions, function-location/length checks,
+  and condition-class assertions for `testthat` expectations that match `regexp`).
 - `undesirable_functions()` — the underlying undesirable-function map, if a repo needs
   to extend it.
 

--- a/lms/tests/testthat/test-condition_class_linter.R
+++ b/lms/tests/testthat/test-condition_class_linter.R
@@ -44,7 +44,7 @@ test_that("expect_message with regexp and class is allowed", {
   )
 })
 
-test_that("calls that do not match on regexp are not flagged", {
+test_that("expect_error without regexp or with info is not flagged", {
   lintr::expect_no_lint("expect_error(f())", lms:::condition_class_linter())
   lintr::expect_no_lint(
     'expect_error(f(), class = "my_pkg_error")',

--- a/lms/tests/testthat/test-condition_class_linter.R
+++ b/lms/tests/testthat/test-condition_class_linter.R
@@ -22,9 +22,24 @@ test_that("expect_warning with regexp and no class is flagged", {
   )
 })
 
+test_that("expect_message with regexp and no class is flagged", {
+  lintr::expect_lint(
+    'expect_message(f(), regexp = "informative")',
+    "include a `class =` assertion",
+    lms:::condition_class_linter()
+  )
+})
+
 test_that("regexp with class is allowed", {
   lintr::expect_no_lint(
     'expect_error(f(), regexp = "bad input", class = "my_pkg_error")',
+    lms:::condition_class_linter()
+  )
+})
+
+test_that("expect_message with regexp and class is allowed", {
+  lintr::expect_no_lint(
+    'expect_message(f(), regexp = "informative", class = "my_pkg_message")',
     lms:::condition_class_linter()
   )
 })

--- a/lms/tests/testthat/test-condition_class_linter.R
+++ b/lms/tests/testthat/test-condition_class_linter.R
@@ -1,0 +1,38 @@
+test_that("expect_error with positional regexp and no class is flagged", {
+  lintr::expect_lint(
+    'expect_error(f(), "bad input")',
+    "include a `class =` assertion",
+    lms:::condition_class_linter()
+  )
+})
+
+test_that("expect_error with named regexp and no class is flagged", {
+  lintr::expect_lint(
+    'expect_error(f(), regexp = "bad input")',
+    "include a `class =` assertion",
+    lms:::condition_class_linter()
+  )
+})
+
+test_that("expect_warning with regexp and no class is flagged", {
+  lintr::expect_lint(
+    'expect_warning(f(), regexp = "deprecated")',
+    "include a `class =` assertion",
+    lms:::condition_class_linter()
+  )
+})
+
+test_that("regexp with class is allowed", {
+  lintr::expect_no_lint(
+    'expect_error(f(), regexp = "bad input", class = "my_pkg_error")',
+    lms:::condition_class_linter()
+  )
+})
+
+test_that("calls that do not match on regexp are not flagged", {
+  lintr::expect_no_lint("expect_error(f())", lms:::condition_class_linter())
+  lintr::expect_no_lint(
+    'expect_error(f(), class = "my_pkg_error")',
+    lms:::condition_class_linter()
+  )
+})

--- a/lms/tests/testthat/test-condition_class_linter.R
+++ b/lms/tests/testthat/test-condition_class_linter.R
@@ -50,4 +50,8 @@ test_that("calls that do not match on regexp are not flagged", {
     'expect_error(f(), class = "my_pkg_error")',
     lms:::condition_class_linter()
   )
+  lintr::expect_no_lint(
+    'expect_error(f(), info = "details")',
+    lms:::condition_class_linter()
+  )
 })


### PR DESCRIPTION
## Summary
- add `condition_class_linter()` to `lms` to flag `expect_error()`, `expect_warning()`, and `expect_message()` calls that match message text without `class =`
- include the new rule in `default_linters()` and add targeted tests for flagged and allowed patterns
- update testing guidance to recommend class-first condition assertions with optional `regexp`

## Why
Matching only condition text is brittle. Condition classes provide a stable contract for tests, while message matching can remain a secondary precision check.

Closes #433
