### PR TITLE
Add guidance against repurposing existing tests for new features

### DIFF
--- a/coding-practices/testing-requirements.qmd
+++ b/coding-practices/testing-requirements.qmd
@@ -1,5 +1,37 @@
 **ALWAYS establish tests BEFORE modifying functions.** This ensures changes preserve existing behavior and new behavior is correctly validated.
 
+### Add New Tests for New Features {#sec-dont-repurpose-tests}
+
+When a PR adds a feature, give it a new test rather than
+editing an existing test's inputs or expectations to also cover it.
+Repurposing a test this way folds two changes into one diff ---
+the reviewer can no longer tell,
+at a glance,
+whether the edited assertions still protect the old behavior
+or now only protect the new one.
+
+```r
+# Avoid --- repurposing an existing test to also cover a new method
+test_that("run_model produces expected output", {
+  result <- run_model(data, method = "exponential") # was "power"
+  expect_snapshot_value(result)
+})
+
+# Preferred --- a new test for the new feature
+test_that("run_model handles the exponential method", {
+  result <- run_model(data, method = "exponential")
+  expect_snapshot_value(result)
+})
+```
+
+If the new feature makes an existing test redundant,
+leave that redundancy alone for now.
+Remove or consolidate redundant tests in a separate, focused PR,
+so a reviewer can evaluate
+"does the new feature work"
+and "which old tests are now redundant"
+as two independent questions.
+
 ### When to Use Snapshot Tests
 
 Use snapshot tests (`expect_snapshot()`, `expect_snapshot_value()`) when:

--- a/coding-practices/testing-requirements.qmd
+++ b/coding-practices/testing-requirements.qmd
@@ -10,6 +10,10 @@ at a glance,
 whether the edited assertions still protect the old behavior
 or now only protect the new one.
 
+For example, suppose a `run_model()` test originally covered the
+`"power"` method and gets edited in place to cover `"exponential"`
+instead, rather than gaining a new test alongside it:
+
 ```r
 # Avoid --- repurposing an existing test to also cover a new method
 test_that("run_model produces expected output", {


### PR DESCRIPTION
Closes #440

## Summary

- Add a new "Add New Tests for New Features" subsection to `coding-practices/testing-requirements.qmd` (@sec-r-testing).
- The guidance: when a PR adds a feature, write a new test for it rather than editing an existing test's inputs/expectations to also cover the new behavior. Repurposing a test this way folds two changes into one diff, so a reviewer can't tell whether the edited assertions still protect the old behavior or now only protect the new one.
- If the new feature makes an existing test redundant, leave that alone for now and handle removal/consolidation of redundant tests in a separate, focused PR.
- Includes a short before/after R code example (`test_that()` snippets, not executable Quarto chunks).

This encodes the review feedback from [UCD-SERG/serodynamics#252 (review comment)](https://github.com/UCD-SERG/serodynamics/pull/252#discussion_r3648294944).

## Testing

- `quarto render coding-practices.qmd --to html` renders cleanly with the new section (verified the TOC entry and rendered HTML output).
- Checked the diff for non-ASCII punctuation (em/en dashes, curly quotes) — none found; used `---` per this repo's convention.
- No new proper nouns/acronyms requiring `inst/WORDLIST` additions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1WasEinjpXvDu9aXMWMNv)_