### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/bump-ai-config.yml
+++ b/.github/workflows/bump-ai-config.yml
@@ -1,5 +1,5 @@
 # Auto-bump the .ai-config submodule to ai-config's main, opening a PR when the
-# pointer moves. Calls d-morrison/gha's reusable bump-submodule workflow.
+# pointer moves. Calls Morrison-Lab/gha's reusable bump-submodule workflow.
 #
 # .ai-config is public, so no SUBMODULES_TOKEN is needed, and the PR is opened in
 # this repo with the integrated GITHUB_TOKEN -- which requires Settings ->
@@ -17,6 +17,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: d-morrison/gha/.github/workflows/bump-submodule.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/bump-submodule.yml@v1
     with:
       submodule-path: .ai-config

--- a/.github/workflows/check-non-standard-chars.yaml
+++ b/.github/workflows/check-non-standard-chars.yaml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   check-chars:
-    uses: d-morrison/gha/.github/workflows/check-non-standard-chars.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-non-standard-chars.yml@v2

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Calls the shared reusable Claude Code Review workflow in d-morrison/gha.
+# Calls the shared reusable Claude Code Review workflow in Morrison-Lab/gha.
 # Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret. It is passed
 # explicitly (not `secrets: inherit`): the reusable workflow lives in the
 # d-morrison user account while this repo is in the UCD-SERG org, and GitHub
@@ -27,7 +27,7 @@ jobs:
       issues: write
       id-token: write
       actions: read   # lets the reviewer read CI status (github_ci MCP server)
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/claude-code-review.yml@v1
     # Pass secrets explicitly — cross-owner `secrets: inherit` drops them (see
     # the header comment). SUBMODULES_TOKEN is optional (empty when unset).
     secrets:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Calls the shared reusable Claude Code workflow in d-morrison/gha.
+# Calls the shared reusable Claude Code workflow in Morrison-Lab/gha.
 # Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret, passed explicitly
 # (not `secrets: inherit`): the reusable workflow is in the d-morrison user
 # account while this repo is in the UCD-SERG org, and cross-owner `inherit`
@@ -33,7 +33,7 @@ jobs:
       issues: write
       id-token: write
       actions: write       # dispatch the review workflow via `gh workflow run`
-    uses: d-morrison/gha/.github/workflows/claude.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/claude.yml@v1
     # Pass secrets explicitly — cross-owner `secrets: inherit` drops them (see
     # the header comment). SUBMODULES_TOKEN / WORKFLOW_TOKEN are optional and
     # resolve to empty when unset.

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,5 +1,5 @@
 # Housekeeping half of the PR-preview family, delegated to the reusable
-# cleanup-pr-previews workflow in d-morrison/gha. Periodically deletes gh-pages
+# cleanup-pr-previews workflow in Morrison-Lab/gha. Periodically deletes gh-pages
 # preview directories for PRs that are no longer open, and (compact-history)
 # orphan-squashes gh-pages to a single commit so the deleted snapshots stop
 # bloating the repo. The calling job grants contents: write so the reusable can
@@ -23,6 +23,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/cleanup-pr-previews.yml@v2
     with:
       compact-history: true


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 9 reference(s) across 5 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.