### PR TITLE
Correct the export-archive section against GitHub's primary docs

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -200,6 +200,12 @@
   organization = {GitHub}
 }
 
+@online{githuborgmigrations,
+  title = {REST API endpoints for organization migrations},
+  url = {https://docs.github.com/en/rest/migrations/orgs},
+  organization = {GitHub}
+}
+
 @online{gitfixum,
   author = {Robertson, Seth},
   title = {On undoing, fixing, or removing commits in git},

--- a/book.bib
+++ b/book.bib
@@ -188,6 +188,18 @@
   organization = {GitHub}
 }
 
+@online{githubaccountarchive,
+  title = {Requesting an archive of your personal account's data},
+  url = {https://docs.github.com/en/get-started/archiving-your-github-personal-account-and-public-repositories/requesting-an-archive-of-your-personal-accounts-data},
+  organization = {GitHub}
+}
+
+@online{githubusermigrations,
+  title = {REST API endpoints for user migrations},
+  url = {https://docs.github.com/en/rest/migrations/users},
+  organization = {GitHub}
+}
+
 @online{gitfixum,
   author = {Robertson, Seth},
   title = {On undoing, fixing, or removing commits in git},

--- a/github/_sec-export-conversations.qmd
+++ b/github/_sec-export-conversations.qmd
@@ -127,10 +127,8 @@ Use `gh api graphql` to issue the query.
 
 ### Whole-repository archives {#sec-export-migration}
 
-For a complete snapshot with no scripting,
 GitHub's migration API builds a downloadable archive of your data as JSON.
-This is the most complete of the routes here,
-and the only one that needs no code at all.
+It is the most complete of the routes here.
 
 The user migrations reference lists what the archive can hold
 [@githubusermigrations].
@@ -143,7 +141,7 @@ along with `issue_events`, `commit_comments`, `milestones`,
 Start a migration with `POST /user/migrations` for repositories you own,
 or `POST /orgs/{org}/migrations` for an organization's repositories
 if you are an organization owner
-([organization migrations](https://docs.github.com/en/rest/migrations/orgs)).
+[@githuborgmigrations].
 Both are asynchronous:
 you poll the migration's status until it reports `exported`,
 then download the archive,
@@ -157,8 +155,9 @@ and refers readers to the migrations API reference
 for what that data covers
 [@githubaccountarchive].
 Clicking through delivers the `.tar.gz` by emailed download link.
-So a lab member who wants the whole record and would rather not script anything
-can get it from Settings.
+That makes this the one route needing no code at all:
+a lab member who wants the whole record
+can click through Settings and skip everything above.
 
 This route is the right one for archiving a repository before it is deleted or transferred.
 The per-repository scripts above are better for

--- a/github/_sec-export-conversations.qmd
+++ b/github/_sec-export-conversations.qmd
@@ -128,26 +128,37 @@ Use `gh api graphql` to issue the query.
 ### Whole-repository archives {#sec-export-migration}
 
 For a complete snapshot with no scripting,
-GitHub's migration API builds a downloadable archive
-containing issues, issue comments, pull requests, and pull request review comments as JSON.
-Start one with `POST /user/migrations` for repositories you own
-([user migrations](https://docs.github.com/en/rest/migrations/users)),
+GitHub's migration API builds a downloadable archive of your data as JSON.
+This is the most complete of the routes here,
+and the only one that needs no code at all.
+
+The user migrations reference lists what the archive can hold
+[@githubusermigrations].
+Every stream named above is in it ---
+`issues`, `issue_comments`, `pull_requests`, `pull_request_reviews`,
+and `review_comments` ---
+along with `issue_events`, `commit_comments`, `milestones`,
+`releases`, `repositories`, and `users`.
+
+Start a migration with `POST /user/migrations` for repositories you own,
 or `POST /orgs/{org}/migrations` for an organization's repositories
 if you are an organization owner
 ([organization migrations](https://docs.github.com/en/rest/migrations/orgs)).
 Both are asynchronous:
 you poll the migration's status until it reports `exported`,
-then download the archive.
+then download the archive,
+which stays available for seven days.
 
-GitHub separately offers an account-level export
-under **Settings > Account > Export account data**,
-which delivers a `.tar.gz` through an emailed download link
-that expires after seven days by default;
-see
-[Requesting an archive of your personal account's data](https://docs.github.com/en/get-started/archiving-your-github-personal-account-and-public-repositories/requesting-an-archive-of-your-personal-accounts-data).
-That page is the place to check what the archive currently contains.
-The migration API above is the documented route
-for issue and pull request conversation data specifically.
+**Settings > Account > Export account data** is the web-interface route
+to this same export rather than a separate feature.
+GitHub's documentation states that you can export your personal account's data
+"through your account settings on GitHub or with the User Migration API",
+and refers readers to the migrations API reference
+for what that data covers
+[@githubaccountarchive].
+Clicking through delivers the `.tar.gz` by emailed download link.
+So a lab member who wants the whole record and would rather not script anything
+can get it from Settings.
 
 This route is the right one for archiving a repository before it is deleted or transferred.
 The per-repository scripts above are better for
@@ -155,12 +166,16 @@ ongoing exports or for a subset of the discussion.
 
 ### Practical cautions {#sec-export-cautions}
 
-- **Attachments are not included.**
-  Images and files pasted into a comment appear as links to GitHub's asset servers.
-  The exported text keeps the URL,
-  not the file.
+- **Whether you get attachment files depends on the route.**
+  Through `gh` or the REST API you get comment text,
+  in which a pasted image or file is a link to GitHub's asset servers ---
+  the URL, not the file.
   Download those separately if they matter,
   and note that assets on a private repository require authentication to fetch.
+  The migration archive is the exception:
+  it carries an `attachments` directory of the files themselves,
+  unless you ask for it to be left out
+  [@githubusermigrations].
 - **The authenticated rate limit is 5000 requests per hour.**
   A few hundred pull requests exported through REST will get close.
   Check your remaining budget with `gh api /rate_limit`.


### PR DESCRIPTION
Follow-up to #447. That PR landed with two claims hedged or wrong because
`docs.github.com` was blocked by the authoring session's network policy,
so they were made against search snippets rather than the primary source.
The block has since been lifted and the page read directly, which settles both.

## 1. The account export is the same export

#447 review flagged the original "personal-account equivalent" framing as a
possible hallucination, and I removed it. Reading the primary page shows the
original framing was right and the removal overcorrected. GitHub states:

> You can export your personal account's data through your account settings on GitHub or with the User Migration API.

and, for what that export covers, refers readers to the migrations API reference.
So **Settings > Account > Export account data** is the web-interface route to the
migration export, not a neighboring product.

The previous text sent readers to the docs page to discover what the archive holds
and implied the migration API was the only route to conversation data. Both are now
stated directly, and the archive's contents are listed rather than deferred:
`issues`, `issue_comments`, `pull_requests`, `pull_request_reviews`, and
`review_comments` are all present, alongside `issue_events`, `commit_comments`,
`milestones`, `releases`, `repositories`, and `users`.

That has a practical consequence worth stating plainly, so the section now does:
the route that needs no code is also the most complete one.

## 2. The attachments caution was wrong for that route

This one is my error, not a review artifact. The bullet asserted flatly that
attachments are never included. True for `gh` and the REST API, where a pasted
image is a link to GitHub's asset servers. **Not** true for the migration archive,
which carries an `attachments` directory of the files themselves unless excluded.

The bullet now turns on which route you took, since that is what decides the answer.

## Citations

Adds three `@online` entries to `book.bib`, matching the existing
`githubdesktop` / `gitfixum` style:

- `githubaccountarchive` -- Requesting an archive of your personal account's data
- `githubusermigrations` -- REST API endpoints for user migrations
- `githuborgmigrations` -- REST API endpoints for organization migrations

## Review rounds

Seven findings across two rounds, all dispositioned. Two changed the text:
the "no code at all" claim sat next to the migration API, whose nearest antecedent
made it read as describing the API (which does need code) rather than the Settings
route; and the org-migrations endpoint was inline-linked while its sibling was cited.

Two were rebutted against the primary source rather than applied:

- **Archive object names.** `review_comments` was suspected of being a hallucinated
  short form of `pull_request_review_comments`. The archive's object list does not
  follow endpoint naming; GitHub documents `pull_request_reviews` and
  `review_comments` verbatim.
- **The seven-day window.** Correctly queried as having moved paragraphs, but it is
  independently documented for the API archive: "Once you've created a migration
  archive, it will be available to download for seven days."

One partial: `exclude_attachments` is an opt-out, but the parameter table prints no
explicit default, so that rests on the archive description and an example payload
rather than a stated default value. Noted on the thread rather than overclaimed.

## Verification

- `quarto render github.qmd` succeeds; all three citations resolve and render
  (no `?@key` or bold-question-mark output anywhere in the HTML).
- `spelling::spell_check_files()` surfaces no new words.
- Changed `.qmd` is ASCII-only; em dashes written as `---` per `CLAUDE.md:115-116`.
  (`book.bib` carries pre-existing non-ASCII in author names, and is outside the
  `.qmd`/`.R` scope of the character check.)
- All seven checks green on `c5a9fd6`.

## Note for the merger

Two review threads are left deliberately unresolved. Both ask a **human** to confirm
the quoted wording against the live docs page. That check has been done against the
primary source (exact match, singular "User Migration API"), but resolving them here
would erase a verification step the reviewer specifically wanted a person to make.

A gap worth its own change: no `@online` entry in `book.bib` carries an access date,
so no quoted documentation wording in the manual is pinned to a point in time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCozDFHV4gMhSJWmrAtkA1)_