### PR TITLE
Document X11 forwarding for GUI applications on Shiva

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -182,6 +182,20 @@
   organization = {SchedMD}
 }
 
+@online{openssh-ssh-config,
+  title = {ssh_config(5) manual page},
+  url = {https://man.openbsd.org/ssh_config},
+  organization = {OpenBSD},
+  note = {Documents ForwardX11Trusted and the twenty-minute default timeout on untrusted X11 forwarding}
+}
+
+@online{openssh-ssh-config-debian,
+  title = {ssh_config(5) manual page, Debian edition},
+  url = {https://manpages.debian.org/stable/openssh-client/ssh_config.5.en.html},
+  organization = {Debian Project},
+  note = {Documents the Debian-specific default of ForwardX11Trusted yes, which differs from the upstream default of no}
+}
+
 @online{githubdesktop,
   title = {GitHub Desktop},
   url = {https://desktop.github.com/},

--- a/slurm.qmd
+++ b/slurm.qmd
@@ -196,6 +196,10 @@ if(Sys.getenv("LMOD_SYSHOST")!=""){
 }
 ```
 
+## Running graphical programs with X11 forwarding {#sec-x11-forwarding}
+
+{{< include slurm/x11-forwarding.qmd >}}
+
 ## Recovering a disconnected interactive session
 
 Interactive sessions on a SLURM cluster ---

--- a/slurm/x11-forwarding.qmd
+++ b/slurm/x11-forwarding.qmd
@@ -23,7 +23,8 @@ because only the page data crosses the network rather than every repainted pixel
 
 The cluster draws into an X server,
 and that server runs on your machine rather than on Shiva.
-macOS and Windows do not ship one.
+macOS and Windows do not ship one,
+so install the software listed in @tbl-x11-servers before your first attempt.
 
 | Your computer | What to install |
 |---------------|-----------------|

--- a/slurm/x11-forwarding.qmd
+++ b/slurm/x11-forwarding.qmd
@@ -31,7 +31,7 @@ so install the software listed in @tbl-x11-servers before your first attempt.
 | macOS | [XQuartz](https://www.xquartz.org/). Log out and back in after installing, so that `DISPLAY` is set. |
 | Windows | [VcXsrv](https://sourceforge.net/projects/vcxsrv/), or [MobaXterm](https://mobaxterm.mobatek.net/), which bundles an X server together with an SSH client. |
 | Windows, using WSL2 | Nothing. [WSLg](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) supplies the X server. |
-| Linux | Nothing. Your desktop session is already an X server. |
+| Linux | Usually nothing. An X11 session is itself an X server; a Wayland session relies on [Xwayland](https://wiki.archlinux.org/title/Wayland) for X11 compatibility. Confirm `DISPLAY` is set locally before you connect. |
 
 : Where to get an X server, by operating system {#tbl-x11-servers}
 

--- a/slurm/x11-forwarding.qmd
+++ b/slurm/x11-forwarding.qmd
@@ -47,7 +47,7 @@ Use `-Y` rather than `-X` here.
 `-X` requests *untrusted* forwarding,
 and by default OpenSSH refuses untrusted X11 connections
 made more than twenty minutes into the session [@openssh-ssh-config].
-Windows already on screen keep working,
+Any window already on screen keeps working,
 so the symptom is that a program you launch later in the session simply never appears.
 Untrusted forwarding also restricts clients under the X11 SECURITY extension,
 to stop them reading or tampering with data belonging to trusted clients

--- a/slurm/x11-forwarding.qmd
+++ b/slurm/x11-forwarding.qmd
@@ -1,0 +1,157 @@
+Shiva's SSH server permits X11 forwarding,
+so a graphical program started on the cluster can draw its window on your own computer.
+This is worth setting up when you want a GUI text editor on the cluster,
+or a web browser that sees the network from Shiva's position rather than from yours.
+
+X11 forwarding sends every window update across the network,
+so it suits a text editor much better than it suits a browser.
+When all you want is to view a web page that Shiva itself is serving,
+such as an [RStudio Server](https://posit.co/products/open-source/rstudio-server/) session
+or a rendered report,
+forward the port instead and use the browser already on your own computer:
+
+```bash
+# from your own computer, not from Shiva
+ssh -L 8787:localhost:8787 USERNAME@shiva.ucdavis.edu
+```
+
+With that running, `http://localhost:8787` in your local browser reaches the service on Shiva.
+This is far faster than forwarding a browser window,
+because only the page data crosses the network rather than every repainted pixel.
+
+### Install an X server on your own computer
+
+The cluster draws into an X server,
+and that server runs on your machine rather than on Shiva.
+macOS and Windows do not ship one.
+
+| Your computer | What to install |
+|---------------|-----------------|
+| macOS | [XQuartz](https://www.xquartz.org/). Log out and back in after installing, so that `DISPLAY` is set. |
+| Windows | [VcXsrv](https://sourceforge.net/projects/vcxsrv/), or [MobaXterm](https://mobaxterm.mobatek.net/), which bundles an X server together with an SSH client. |
+| Windows, using WSL2 | Nothing. [WSLg](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gui-apps) supplies the X server. |
+| Linux | Nothing. Your desktop session is already an X server. |
+
+: Where to get an X server, by operating system {#tbl-x11-servers}
+
+### Connect with X11 forwarding enabled
+
+Ask for trusted X11 forwarding with `-Y`:
+
+```bash
+ssh -Y USERNAME@shiva.ucdavis.edu
+```
+
+Use `-Y` rather than `-X` here.
+`-X` requests *untrusted* forwarding,
+which OpenSSH shuts off twenty minutes into the session by default [@openssh-ssh-config],
+so a long editing session dies partway through for no visible reason.
+Many graphical toolkits also misbehave under the untrusted restrictions.
+
+The exception is a Linux client running Debian or Ubuntu,
+where `ForwardX11Trusted` defaults to `yes`
+and `-X` therefore already means the same thing as `-Y` [@openssh-ssh-config-debian].
+Passing `-Y` is correct on every platform, so prefer it and do not worry about which case you are in.
+
+Trusted forwarding is a real tradeoff rather than a free upgrade.
+It gives programs running on Shiva full access to your local display,
+which includes reading input directed at your other windows [@openssh-ssh-config].
+That is an acceptable risk for a cluster our lab administers and trusts;
+do not extend the same setting to machines you do not trust.
+
+To avoid retyping the flag, add an entry to `~/.ssh/config` on your own computer:
+
+```
+Host shiva
+  HostName shiva.ucdavis.edu
+  User USERNAME
+  ForwardX11 yes
+  ForwardX11Trusted yes
+  Compression yes
+```
+
+`ssh shiva` then forwards X11 automatically.
+`Compression yes` is worth setting because X11 traffic compresses well over a slow link.
+
+### Check that the forward is working
+
+After logging in, `DISPLAY` should be set:
+
+```bash
+echo $DISPLAY
+# localhost:10.0
+```
+
+An empty result means the forward did not happen.
+The usual causes are omitting `-Y`,
+or not having an X server running on your own computer.
+
+To confirm that the connection reaches your display, ask the display to describe itself:
+
+```bash
+xdpyinfo | head -3
+```
+
+Use `xdpyinfo` rather than `xeyes` for this test.
+Shiva has the `x11-utils` package, which provides `xdpyinfo`,
+but not `x11-apps`, which provides `xeyes` and `xclock` (checked August 2026).
+
+### Install graphical programs without `sudo`
+
+Lab accounts on Shiva are not in the `sudo` group,
+which is reserved for the system administrators (checked August 2026).
+Run `groups` to see your own.
+This means `apt install` is unavailable,
+and most installation instructions written for Ubuntu will not apply.
+Install into your home directory instead, which needs no special privileges.
+
+Note that this is necessary even for programs that appear to be present already.
+The system Emacs at `/usr/bin/emacs` is the `emacs-nox` build,
+which links no X libraries at all and so cannot open a window under any circumstances.
+No web browser is installed on Shiva.
+Nothing in `module avail` supplies either one.
+
+For Emacs, use [conda-forge](https://conda-forge.org/),
+whose build includes GTK and X11 support.
+If you do not already have conda,
+install [Miniforge](https://github.com/conda-forge/miniforge) into your home directory first.
+
+```bash
+conda create -y -n gui -c conda-forge emacs
+conda activate gui
+emacs &
+```
+
+For Firefox, use Mozilla's official Linux build,
+which is a self-contained directory that runs from anywhere:
+
+```bash
+mkdir -p ~/opt && cd ~/opt
+curl -L -o firefox.tar.xz \
+  'https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US'
+tar xf firefox.tar.xz && rm firefox.tar.xz
+~/opt/firefox/firefox &
+```
+
+Adding `~/bin` to your `PATH` and putting small wrapper scripts there
+saves typing the full path each time.
+
+### Limitations
+
+**R cannot open plot windows on Shiva.**
+The installed R is built without X11 support,
+which you can confirm with `capabilities()["X11"]`.
+No amount of forwarding configuration changes this,
+because the R binary itself has no X11 device compiled in.
+Write plots to a file with [`{ragg}`](https://ragg.r-lib.org/) or `ggplot2::ggsave()`
+and copy them back with `scp`,
+or forward a port and use a browser-based graphics device such as
+[`{httpgd}`](https://cran.r-project.org/package=httpgd).
+
+**The faster remote-desktop tools are unavailable.**
+[Xpra](https://github.com/Xpra-org/xpra), VNC, and [X2Go](https://wiki.x2go.org/)
+all compress far better than plain X11 forwarding over a slow link.
+All of them need an X server installed on the cluster itself,
+which requires root,
+so none can be set up from a lab account.
+Contact the cluster administrators if the performance of plain forwarding is blocking your work.

--- a/slurm/x11-forwarding.qmd
+++ b/slurm/x11-forwarding.qmd
@@ -1,4 +1,4 @@
-Shiva's SSH server permits X11 forwarding,
+Shiva's SSH server permits X11 forwarding (checked August 2026),
 so a graphical program started on the cluster can draw its window on your own computer.
 This is worth setting up when you want a GUI text editor on the cluster,
 or a web browser that sees the network from Shiva's position rather than from yours.
@@ -45,9 +45,14 @@ ssh -Y USERNAME@shiva.ucdavis.edu
 
 Use `-Y` rather than `-X` here.
 `-X` requests *untrusted* forwarding,
-which OpenSSH shuts off twenty minutes into the session by default [@openssh-ssh-config],
-so a long editing session dies partway through for no visible reason.
-Many graphical toolkits also misbehave under the untrusted restrictions.
+and by default OpenSSH refuses untrusted X11 connections
+made more than twenty minutes into the session [@openssh-ssh-config].
+Windows already on screen keep working,
+so the symptom is that a program you launch later in the session simply never appears.
+Untrusted forwarding also restricts clients under the X11 SECURITY extension,
+to stop them reading or tampering with data belonging to trusted clients
+[@openssh-ssh-config],
+and some graphical toolkits fail outright under those restrictions.
 
 The exception is a Linux client running Debian or Ubuntu,
 where `ForwardX11Trusted` defaults to `yes`
@@ -100,8 +105,8 @@ but not `x11-apps`, which provides `xeyes` and `xclock` (checked August 2026).
 ### Install graphical programs without `sudo`
 
 Lab accounts on Shiva are not in the `sudo` group,
-which is reserved for the system administrators (checked August 2026).
-Run `groups` to see your own.
+which held only a handful of administrator accounts when this was checked in August 2026.
+Run `groups` to see which groups your own account belongs to.
 This means `apt install` is unavailable,
 and most installation instructions written for Ubuntu will not apply.
 Install into your home directory instead, which needs no special privileges.
@@ -110,7 +115,8 @@ Note that this is necessary even for programs that appear to be present already.
 The system Emacs at `/usr/bin/emacs` is the `emacs-nox` build,
 which links no X libraries at all and so cannot open a window under any circumstances.
 No web browser is installed on Shiva.
-Nothing in `module avail` supplies either one.
+`module avail` on the login node lists only MPI and numerical libraries,
+so it supplies neither one.
 
 For Emacs, use [conda-forge](https://conda-forge.org/),
 whose build includes GTK and X11 support.


### PR DESCRIPTION
Closes #451

Adds a section to the HPC chapter on running graphical programs on Shiva over X11
forwarding, following the chapter-include convention: a `##` heading in `slurm.qmd`
plus a new `slurm/x11-forwarding.qmd` fragment.

## What it covers

1. **When not to use it.** If the goal is a web page Shiva is serving, `ssh -L` and a
   local browser is dramatically faster, since only page data crosses the network
   rather than every repainted pixel. That comes first, so nobody sets up X11
   forwarding for a job port forwarding does better.
2. **Installing an X server** on macOS, Windows, WSL2, and Linux.
3. **Connecting with `-Y`**, the `~/.ssh/config` entry, and the security tradeoff
   trusted forwarding carries.
4. **Verifying** the forward with `DISPLAY` and `xdpyinfo`.
5. **Installing GUI programs without `sudo`**, which is necessary on Shiva.
6. **Limitations**, including two that will otherwise cost someone an afternoon.

## Why the "without sudo" section is needed

Three things on Shiva make the obvious first attempt fail confusingly, all checked
on the cluster on 2026-08-04:

- `/usr/bin/emacs` is the `emacs-nox` build. `ldd` finds no X libraries linked, and
  it ignores `--display` entirely, so it can never open a window.
- No web browser is installed, and `module avail` offers neither one.
- R is built without X11 (`capabilities()["X11"]` is `FALSE`), so interactive plot
  windows cannot work regardless of forwarding.

## Verification

- Rendered `slurm.qmd` to HTML locally. `@tbl-x11-servers` and both citations resolve;
  the rendered page contains no `?@` unresolved crossrefs and no `**key?**` missing
  citations.
- All 12 external URLs in the new fragment return HTTP 200 (checked 2026-08-04). The
  `http://localhost:8787` example is already covered by `lychee.toml`'s exclude list.
- `check-non-standard-chars` passes, verified against a planted-em-dash control to
  confirm the detector actually fires.
- `check-new-line-breaks` reports no lines missing semantic breaks.

## Citations

The `-X` versus `-Y` claim is split across two sources deliberately, because the
defaults differ. The twenty-minute untrusted-forwarding timeout is in upstream
OpenSSH's `ssh_config(5)`; the "`ForwardX11Trusted` defaults to yes" behaviour is
Debian-specific and documented only in Debian's edition of that page. Both are cited
where each claim is made.

## Note on `link-checker`

That check is red, and it is **pre-existing and unrelated to this PR**. Every error is
a 404 on `https://d-morrison.github.io/wai/...` from `ai-tools.qmd`, `github.qmd`,
`coding-practices/`, and `continuous-integration/` -- none from this diff. It fails on
`main` at this PR's own base commit (`49e00f11`) too. Filed separately.

The redirects this diff's links produce are not failures: `lychee.toml`'s `accept` list
already includes 301, 302, and 303.
