### PR TITLE
fix(links): point wai references at morrison-lab.github.io

### DIFF
--- a/ai-tools.qmd
+++ b/ai-tools.qmd
@@ -1,7 +1,7 @@
 # Working with AI
 
 Our notes on working responsibly and effectively with AI coding assistants
-have moved to a dedicated site: **[Working with AI](https://d-morrison.github.io/wai/)**
+have moved to a dedicated site: **[Working with AI](https://morrison-lab.github.io/wai/)**
 (source: <https://github.com/d-morrison/wai>).
 
 That site covers:
@@ -13,16 +13,16 @@ That site covers:
 []{#sec-ai-copilot-settings}[]{#sec-ai-agent-skills}[]{#sec-ai-claude-cloud-env}
 []{#sec-ai-when-to-use}[]{#sec-ai-claude-code-windows}[]{#sec-fully-clean}
 
-- [**Policies for Using AI**](https://d-morrison.github.io/wai/chapters/ai-use-policies.html):
+- [**Policies for Using AI**](https://morrison-lab.github.io/wai/chapters/ai-use-policies.html):
   responsibility for validation, disclosure, attribution, and using AI for
   journal articles
 
-- [**Coding Agents**](https://d-morrison.github.io/wai/chapters/coding-agents.html):
+- [**Coding Agents**](https://morrison-lab.github.io/wai/chapters/coding-agents.html):
   what language models, coding agents, and harnesses are; how to work with
   them; benefits, hazards, and best practices; and configuring your
   environment
 
-- [**Pull-Request Workflow with Agents**](https://d-morrison.github.io/wai/chapters/pr-workflow-with-agents.html):
+- [**Pull-Request Workflow with Agents**](https://morrison-lab.github.io/wai/chapters/pr-workflow-with-agents.html):
   filing issues, claiming work, and driving a pull request to a clean,
   mergeable state
 

--- a/coding-practices/benchmarking.qmd
+++ b/coding-practices/benchmarking.qmd
@@ -368,7 +368,7 @@ jobs:
 - **Manual triggers**: Use `workflow_dispatch` for on-demand benchmarking
 - **Security**: For production workflows, consider pinning action versions to
   commit SHAs instead of tags
-  (see the [wai site's "Best Practices for Safe and Successful Use" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices))
+  (see the [wai site's "Best Practices for Safe and Successful Use" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices))
 
 **Alternative: Comment benchmark results on PRs:**
 

--- a/continuous-integration/pull-request-comment-automation.qmd
+++ b/continuous-integration/pull-request-comment-automation.qmd
@@ -227,6 +227,6 @@ be careful about what information you expose in comments,
 as fork contributors can trigger these workflows.
 Never expose secrets or sensitive information in PR comments.
 
-See the [wai site's "Best Practices for Safe and Successful Use" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices)
+See the [wai site's "Best Practices for Safe and Successful Use" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices)
 for more guidance on workflow security.
 :::

--- a/continuous-integration/troubleshooting-workflows.qmd
+++ b/continuous-integration/troubleshooting-workflows.qmd
@@ -24,4 +24,4 @@ Common causes of CI failures include:
 - **Linting errors**: Code style issues detected by automated checks
 
 For help addressing workflow failures,
-see the [wai site's "Addressing Failing GitHub Actions Workflows" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-addressing-failing-workflows).
+see the [wai site's "Addressing Failing GitHub Actions Workflows" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-addressing-failing-workflows).

--- a/continuous-integration/workflow-files-and-security.qmd
+++ b/continuous-integration/workflow-files-and-security.qmd
@@ -5,7 +5,7 @@ Workflow files (`.github/workflows/*.yaml`) have access to repository secrets an
 Always review workflow files carefully before committing them,
 especially if copied from external sources.
 
-See the [wai site's "Best Practices for Safe and Successful Use" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices)
+See the [wai site's "Best Practices for Safe and Successful Use" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices)
 for guidance on working with workflow files using AI tools.
 :::
 

--- a/github.qmd
+++ b/github.qmd
@@ -74,7 +74,7 @@ GitHub Copilot settings page showing organization options
    follow the setup instructions to install and configure Copilot in your development environment
 
 For guidance on using GitHub Copilot effectively,
-see the [wai site's "Best Practices for Safe and Successful Use" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices).
+see the [wai site's "Best Practices for Safe and Successful Use" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-best-practices).
 
 ## GitHub Desktop
 While knowing how to use Git on the command line will always be useful

--- a/github/_sec-cli-tools.qmd
+++ b/github/_sec-cli-tools.qmd
@@ -23,7 +23,7 @@ gh auth login
 ```
 
 On Windows with Git Bash or MSYS2,
-see the [wai site's "Installing Claude Code on Windows" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-claude-code-windows)
+see the [wai site's "Installing Claude Code on Windows" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-claude-code-windows)
 for the `winpty` workaround if the interactive
 prompt fails.
 
@@ -47,6 +47,6 @@ glab auth login
 ```
 
 On Windows with Git Bash or MSYS2,
-see the [wai site's "Installing Claude Code on Windows" section](https://d-morrison.github.io/wai/chapters/coding-agents.html#sec-ai-claude-code-windows)
+see the [wai site's "Installing Claude Code on Windows" section](https://morrison-lab.github.io/wai/chapters/coding-agents.html#sec-ai-claude-code-windows)
 for the `winpty` workaround if the interactive
 prompt fails.

--- a/manuscript-preparation.qmd
+++ b/manuscript-preparation.qmd
@@ -118,7 +118,7 @@ manuscripts, documentation, grant applications, and technical reports.
 
 When using AI tools to help develop manuscripts or other academic writing,
 follow the special guidance in the
-[wai site's "Using AI for Journal Articles" section](https://d-morrison.github.io/wai/chapters/ai-use-policies.html#sec-ai-journal-articles)
+[wai site's "Using AI for Journal Articles" section](https://morrison-lab.github.io/wai/chapters/ai-use-policies.html#sec-ai-journal-articles)
 to ensure transparency,
 maintain intellectual ownership,
 and avoid plagiarism.


### PR DESCRIPTION
Closes #453

The wai site moved with its repo. All 12 references across 8 files 404, and `link-checker` has been red on `main` since at least 2026-08-04 as a result.

## Verified before replacing

The paths could have moved along with the host, so each was checked rather than assumed:

| URL | Status |
|---|---|
| `https://morrison-lab.github.io/wai/` | 200 |
| `.../chapters/ai-use-policies.html` | 200 |
| `.../chapters/coding-agents.html` | 200 |
| `.../chapters/pr-workflow-with-agents.html` | 200 |

All four targeted anchors exist in the new pages, confirmed by grepping the served HTML for `id="..."`: `sec-ai-best-practices`, `sec-ai-addressing-failing-workflows`, `sec-ai-claude-code-windows`, `sec-ai-journal-articles`.

## Scope

Host only --- `d-morrison.github.io/wai` becomes `morrison-lab.github.io/wai`. Every path and fragment is byte-identical, and the old host has 0 remaining occurrences. 12 replacements across `ai-tools.qmd` (4), `github/_sec-cli-tools.qmd` (2), and six files with one each.

This clears one of the two repo-wide red checks. The other, `check-chars`, is tracked in #462 and is unrelated to this diff.
