### PR TITLE
fix(chars): replace the nine non-ASCII characters in benchmarking.qmd

### DIFF
--- a/coding-practices/benchmarking.qmd
+++ b/coding-practices/benchmarking.qmd
@@ -97,12 +97,12 @@ results <- bench::mark(
 
 # View results
 print(results)
-#> # A tibble: 3 × 6
+#> # A tibble: 3 x 6
 #>   expression        min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
 #> 1 base_subset    1.2ms    1.4ms       714.    1.5MB     2.14
 #> 2 dplyr_filter   2.1ms    2.3ms       435.    2.1MB     4.35
-#> 3 data.table   850.0µs  950.0µs      1053.  800.0KB     0.00
+#> 3 data.table   850.0us  950.0us      1053.  800.0KB     0.00
 
 # Plot results
 plot(results)
@@ -210,10 +210,10 @@ profvis({
 
 **Common bottlenecks in epidemiology code:**
 
-- Repeated subsetting operations → Use data.table or pre-filter
-- Growing objects in loops → Pre-allocate vectors
-- Complex joins on large datasets → Index properly or use data.table
-- Unnecessary copies → Use reference semantics where appropriate
+- Repeated subsetting operations -> Use data.table or pre-filter
+- Growing objects in loops -> Pre-allocate vectors
+- Complex joins on large datasets -> Index properly or use data.table
+- Unnecessary copies -> Use reference semantics where appropriate
 
 ### Integration with Package Development Workflow
 
@@ -439,13 +439,13 @@ test_that("analysis scales linearly with sample size", {
     as.numeric(result$median)
   }, numeric(1))
   
-  # Check approximate linearity (R² > 0.95)
+  # Check approximate linearity (R^2 > 0.95)
   model <- lm(timings ~ sizes)
   r_squared <- summary(model)$r.squared
   
   expect_true(
     r_squared > 0.95,
-    info = sprintf("Scaling R² = %.3f (expected > 0.95)", r_squared)
+    info = sprintf("Scaling R^2 = %.3f (expected > 0.95)", r_squared)
   )
 })
 ```


### PR DESCRIPTION
Closes #462

`check-non-standard-chars` has been failing on **every** PR in the repo. This clears it.

## What was actually there

The checker reports one character because its glyph set covers one. The file carries four distinct code points at nine sites:

| Code point | Sites | Replacement |
|---|---|---|
| U+00D7 MULTIPLICATION SIGN | 1 | `x` |
| U+00B5 MICRO SIGN | 2 | `u` |
| U+2192 RIGHTWARDS ARROW | 4 | `->` |
| U+00B2 SUPERSCRIPT TWO | 2 | `^2` |

All nine predate the check failing --- they came in with `0030720` (2026-01-27) and only surfaced when `Morrison-Lab/gha`'s glyph set gained U+00D7. Fixing only the flagged one would leave seven to be reported as that set grows, so all nine go.

## The one judgment call

Two sites sit inside a `#>` block showing `bench::mark()` output, which raises the question of whether rewriting them makes a transcript no longer verbatim.

It does not. That block's figures are round invented ones --- `1.2ms`, `714.`, `1.5MB` --- so it was always an illustration of shape rather than a captured run. Column alignment survives regardless, since U+00B5 and `u` are both one character wide.

The two `R^2` sites are an R comment and an `sprintf()` format string whose output a developer reads on test failure; `^2` is the conventional ASCII spelling in both.

## Verification

- 0 non-ASCII characters remain in the file.
- The diff modifies 8 lines and changes nothing on them but the substitutions above, confirmed by reading every changed line through `cat -A` rather than a `+`/`-` grep --- the four bullet lines begin with `-`, so a naive `grep -v '^[+-][+-]'` silently drops them and reports half the diff.
